### PR TITLE
[WIP] Adds RPC_UNICODE_STRING support

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/io/PacketOutput.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/PacketOutput.java
@@ -76,7 +76,17 @@ public class PacketOutput extends PrimitiveOutput {
         align();
     }
 
-    public void writeString(final String string, final boolean nullTerminate)
+    public void writeStringBufferRef(final String string, final boolean nullTerminate)
+        throws IOException {
+        if (string != null) {
+            writeReferentID();
+            writeStringBuffer(string, nullTerminate);
+        } else {
+            writeNull();
+        }
+    }
+
+    public void writeStringBuffer(final String string, final boolean nullTerminate)
         throws IOException {
         final int maximumBytes;
         final int currentBytes;
@@ -100,15 +110,7 @@ public class PacketOutput extends PrimitiveOutput {
 
         if (string != null) {
             writeReferentID();
-            writeInt(maximumChars);
-            writeInt(0);
-            writeInt(currentChars);
-            writeChars(string);
-
-            if (nullTerminate) {
-                writeShort((short) 0);
-            }
-
+            writeString(string, maximumChars, currentChars, nullTerminate);
             align();
         } else {
             writeNull();
@@ -117,11 +119,39 @@ public class PacketOutput extends PrimitiveOutput {
 
     public void writeStringRef(final String string, final boolean nullTerminate)
         throws IOException {
+        writeReferentID();
+        writeString(string, nullTerminate);
+        align();
+    }
+
+    public void writeString(final String string, final boolean nullTerminate)
+        throws IOException {
+        final int maximumChars;
+        final int currentChars;
+
+        if (string == null) {
+            maximumChars = 0;
+            currentChars = 0;
+        } else {
+            maximumChars = string.length() + (nullTerminate ? 1 : 0);
+            currentChars = string.length() + (nullTerminate ? 1 : 0);
+        }
+
         if (string != null) {
-            writeReferentID();
-            writeString(string, nullTerminate);
+            writeString(string, maximumChars, currentChars, nullTerminate);
         } else {
             writeNull();
+        }
+    }
+
+    private void writeString(final String string, final int maximumChars, final int currentChars, final boolean nullTerminate)
+       throws IOException {
+        writeInt(maximumChars); //max_is (max size)
+        writeInt(0); //min_is (offset)
+        writeInt(currentChars); //size_is (actual size)
+        writeChars(string);
+        if (nullTerminate) {
+            writeShort((short) 0);
         }
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegOpenKey.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegOpenKey.java
@@ -370,7 +370,7 @@ public class BaseRegOpenKey extends RequestCall<HandleResponse> {
         //          Standard rights: 0x00000000
         //          WINREG specific rights: 0x00000000
         packetOut.write(hKey.getBytes());
-        packetOut.writeString(subKey, true);
+        packetOut.writeStringBuffer(subKey, true);
         packetOut.writeInt(options);
         packetOut.writeInt((int) EnumUtils.toLong(accessMask));
     }

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegQueryValueRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegQueryValueRequest.java
@@ -257,7 +257,7 @@ public class BaseRegQueryValueRequest extends RequestCall<BaseRegQueryValueRespo
         //          Referent ID: 0x00020010
         //          Data Length: 0
         packetOut.write(hKey.getBytes());
-        packetOut.writeString(valueName, true);
+        packetOut.writeStringBuffer(valueName, true);
         packetOut.writeIntRef(0);
         packetOut.writeEmptyArrayRef(dataLen);
         packetOut.writeIntRef(dataLen);

--- a/src/test/java/com/rapid7/client/dcerpc/io/Test_PacketOutput.java
+++ b/src/test/java/com/rapid7/client/dcerpc/io/Test_PacketOutput.java
@@ -86,7 +86,7 @@ public class Test_PacketOutput {
         throws IOException {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final PacketOutput packetOut = new PacketOutput(outputStream);
-        packetOut.writeString(null, true);
+        packetOut.writeStringBuffer(null, true);
         assertEquals("0000000000000000", Hex.toHexString(outputStream.toByteArray()).toUpperCase());
     }
 
@@ -95,7 +95,7 @@ public class Test_PacketOutput {
         throws IOException {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final PacketOutput packetOut = new PacketOutput(outputStream);
-        packetOut.writeString("?", true);
+        packetOut.writeStringBuffer("?", true);
         assertEquals("04000400000002000200000000000000020000003F000000",
             Hex.toHexString(outputStream.toByteArray()).toUpperCase());
     }
@@ -105,7 +105,7 @@ public class Test_PacketOutput {
         throws IOException {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final PacketOutput packetOut = new PacketOutput(outputStream);
-        packetOut.writeStringRef(null, true);
+        packetOut.writeStringBufferRef(null, true);
         assertEquals("00000000", Hex.toHexString(outputStream.toByteArray()).toUpperCase());
     }
 
@@ -114,7 +114,7 @@ public class Test_PacketOutput {
         throws IOException {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final PacketOutput packetOut = new PacketOutput(outputStream);
-        packetOut.writeStringRef("?", true);
+        packetOut.writeStringBufferRef("?", true);
         assertEquals("0000020004000400040002000200000000000000020000003F000000",
             Hex.toHexString(outputStream.toByteArray()).toUpperCase());
     }


### PR DESCRIPTION
• Renames writeStringRef to writeStringBufferRef, which is what is used by winreg
• Renames writeString to writeStringBuffer, because it's actually writing a buffer
• Adds writeString and writeStringRef which represents RPC_UNICODE_STRING