### PR TITLE
Added support for SAMR close handle

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
@@ -37,35 +37,35 @@ public class SecurityAccountManagerService {
     private final RPCTransport transport;
 
     public SecurityAccountManagerService(RPCTransport transport) {
-	this.transport = transport;
+        this.transport = transport;
     }
 
     public ServerHandle getServerHandle(String serverName) throws IOException {
-	final SamrConnect2Request request = new SamrConnect2Request(serverName, EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
-	final SamrConnect2Response response = transport.call(request);
-	return response.getHandle();
+        final SamrConnect2Request request = new SamrConnect2Request(serverName, EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
+        final SamrConnect2Response response = transport.call(request);
+        return response.getHandle();
     }
 
     public DomainHandle openDomain(String serverName, SID sid) throws IOException {
-	final ServerHandle handle = getServerHandle(serverName);
-	final SamrOpenDomainRequest request = new SamrOpenDomainRequest(handle, sid,
-		EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
-	final SamrOpenDomainResponse response = transport.call(request);
-	return response.getHandle();
+        final ServerHandle handle = getServerHandle(serverName);
+        final SamrOpenDomainRequest request = new SamrOpenDomainRequest(handle, sid,
+            EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
+        final SamrOpenDomainResponse response = transport.call(request);
+        return response.getHandle();
     }
 
     public DomainHandle openDomain(ServerHandle serverHandle, SID sid) throws IOException {
-	final SamrOpenDomainRequest request = new SamrOpenDomainRequest(serverHandle, sid,
-		EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
-	final SamrOpenDomainResponse response = transport.call(request);
-	return response.getHandle();
+        final SamrOpenDomainRequest request = new SamrOpenDomainRequest(serverHandle, sid,
+            EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
+        final SamrOpenDomainResponse response = transport.call(request);
+        return response.getHandle();
     }
 
     public void closeHandle(ContextHandle handle) throws IOException {
-	final SamrCloseHandleRequest request = new SamrCloseHandleRequest(handle);
-	final SamrCloseHandleResponse response = transport.call(request);
+        final SamrCloseHandleRequest request = new SamrCloseHandleRequest(handle);
+        final SamrCloseHandleResponse response = transport.call(request);
 
-	if (response.getReturnValue() != 0)
-	    throw new IOException("Failed to close handle: " + new String(handle.getBytes()));
+        if (response.getReturnValue() != 0)
+            throw new IOException("Failed to close handle: " + new String(handle.getBytes()));
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
@@ -22,12 +22,15 @@ import java.io.IOException;
 import java.util.EnumSet;
 import com.hierynomus.msdtyp.AccessMask;
 import com.hierynomus.msdtyp.SID;
+import com.rapid7.client.dcerpc.mssamr.messages.SamrCloseHandleRequest;
+import com.rapid7.client.dcerpc.mssamr.messages.SamrCloseHandleResponse;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrConnect2Request;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrConnect2Response;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenDomainRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenDomainResponse;
 import com.rapid7.client.dcerpc.mssamr.objects.DomainHandle;
 import com.rapid7.client.dcerpc.mssamr.objects.ServerHandle;
+import com.rapid7.client.dcerpc.objects.ContextHandle;
 import com.rapid7.client.dcerpc.transport.RPCTransport;
 
 public class SecurityAccountManagerService {
@@ -46,15 +49,23 @@ public class SecurityAccountManagerService {
     public DomainHandle openDomain(String serverName, SID sid) throws IOException {
 	final ServerHandle handle = getServerHandle(serverName);
 	final SamrOpenDomainRequest request = new SamrOpenDomainRequest(handle, sid,
-	        EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
+		EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
 	final SamrOpenDomainResponse response = transport.call(request);
 	return response.getHandle();
     }
 
     public DomainHandle openDomain(ServerHandle serverHandle, SID sid) throws IOException {
 	final SamrOpenDomainRequest request = new SamrOpenDomainRequest(serverHandle, sid,
-	        EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
+		EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
 	final SamrOpenDomainResponse response = transport.call(request);
 	return response.getHandle();
+    }
+
+    public void closeHandle(ContextHandle handle) throws IOException {
+	final SamrCloseHandleRequest request = new SamrCloseHandleRequest(handle);
+	final SamrCloseHandleResponse response = transport.call(request);
+
+	if (response.getReturnValue() != 0)
+	    throw new IOException("Failed to close handle: " + new String(handle.getBytes()));
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrCloseHandleRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrCloseHandleRequest.java
@@ -29,17 +29,17 @@ public class SamrCloseHandleRequest extends RequestCall<SamrCloseHandleResponse>
     private final ContextHandle handle;
 
     public SamrCloseHandleRequest(ContextHandle handle) {
-	super(OP_NUM);
-	this.handle = handle;
+        super(OP_NUM);
+        this.handle = handle;
     }
 
     @Override
     public void marshal(PacketOutput packetOut) throws IOException {
-	packetOut.write(handle.getBytes());
+        packetOut.write(handle.getBytes());
     }
 
     @Override
     public SamrCloseHandleResponse getResponseObject() {
-	return new SamrCloseHandleResponse();
+        return new SamrCloseHandleResponse();
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrCloseHandleRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrCloseHandleRequest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ */
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.messages.RequestCall;
+import com.rapid7.client.dcerpc.objects.ContextHandle;
+
+public class SamrCloseHandleRequest extends RequestCall<SamrCloseHandleResponse>{
+    public static short OP_NUM = 1;
+
+    private final ContextHandle handle;
+
+    public SamrCloseHandleRequest(ContextHandle handle) {
+	super(OP_NUM);
+	this.handle = handle;
+    }
+
+    @Override
+    public void marshal(PacketOutput packetOut) throws IOException {
+	packetOut.write(handle.getBytes());
+    }
+
+    @Override
+    public SamrCloseHandleResponse getResponseObject() {
+	return new SamrCloseHandleResponse();
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrCloseHandleResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrCloseHandleResponse.java
@@ -29,13 +29,13 @@ public class SamrCloseHandleResponse extends RequestResponse {
 
     @Override
     public void unmarshal(PacketInput in) throws IOException {
-	// SAMR handle is 20 bytes
-	ContextHandle handle = new ContextHandle();
-	handle.unmarshall(in);
-	returnValue = in.readInt();
+        // SAMR handle is 20 bytes
+        ContextHandle handle = new ContextHandle();
+        handle.unmarshall(in);
+        returnValue = in.readInt();
     }
 
     public int getReturnValue() {
-	return returnValue;
+        return returnValue;
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrCloseHandleResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrCloseHandleResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ */
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.messages.RequestResponse;
+import com.rapid7.client.dcerpc.objects.ContextHandle;
+
+public class SamrCloseHandleResponse extends RequestResponse {
+
+    private int returnValue;
+
+    @Override
+    public void unmarshal(PacketInput in) throws IOException {
+	// SAMR handle is 20 bytes
+	ContextHandle handle = new ContextHandle();
+	handle.unmarshall(in);
+	returnValue = in.readInt();
+    }
+
+    public int getReturnValue() {
+	return returnValue;
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrCloseHandleRequest.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrCloseHandleRequest.java
@@ -28,22 +28,21 @@ import com.rapid7.client.dcerpc.objects.ContextHandle;
 
 public class Test_SamrCloseHandleRequest {
     SamrCloseHandleRequest request = new SamrCloseHandleRequest(
-	    new ContextHandle("0000000032daf234b77c86409d29efe60d326683"));
+        new ContextHandle("0000000032daf234b77c86409d29efe60d326683"));
 
     @Test
     public void getOpNum() {
-	assertEquals(SamrCloseHandleRequest.OP_NUM, request.getOpNum());
-    }
-    @Test
-    public void getStub()
-	    throws IOException {
-	assertEquals("0000000032daf234b77c86409d29efe60d326683", toHexString(request.getStub()));
+        assertEquals(SamrCloseHandleRequest.OP_NUM, request.getOpNum());
     }
 
     @Test
-    public void getResponseObject()
-	    throws IOException {
-	assertThat(request.getResponseObject(), instanceOf(SamrCloseHandleResponse.class));
+    public void getStub() throws IOException {
+        assertEquals("0000000032daf234b77c86409d29efe60d326683", toHexString(request.getStub()));
+    }
+
+    @Test
+    public void getResponseObject() throws IOException {
+        assertThat(request.getResponseObject(), instanceOf(SamrCloseHandleResponse.class));
     }
 
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrCloseHandleRequest.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrCloseHandleRequest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ */
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import static org.bouncycastle.util.encoders.Hex.toHexString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import java.io.IOException;
+import org.junit.Test;
+import com.rapid7.client.dcerpc.objects.ContextHandle;
+
+public class Test_SamrCloseHandleRequest {
+    SamrCloseHandleRequest request = new SamrCloseHandleRequest(
+	    new ContextHandle("0000000032daf234b77c86409d29efe60d326683"));
+
+    @Test
+    public void getOpNum() {
+	assertEquals(SamrCloseHandleRequest.OP_NUM, request.getOpNum());
+    }
+    @Test
+    public void getStub()
+	    throws IOException {
+	assertEquals("0000000032daf234b77c86409d29efe60d326683", toHexString(request.getStub()));
+    }
+
+    @Test
+    public void getResponseObject()
+	    throws IOException {
+	assertThat(request.getResponseObject(), instanceOf(SamrCloseHandleResponse.class));
+    }
+
+}


### PR DESCRIPTION
Tested the following snippet
```
	SecurityAccountManagerService service = new SecurityAccountManagerService(transport);
	service.openDomain("", SID.fromString("S-1-5-32"));
	ServerHandle handle = service.getServerHandle("");
	DomainHandle handle2 = service.openDomain(handle, SID.fromString("S-1-5-32"));
	service.closeHandle(handle2);
	service.closeHandle(handle);
	connection.close();
```