### PR TITLE
Adds RPC_UNICODE_STRING

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/io/PacketInput.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/PacketInput.java
@@ -31,6 +31,7 @@ public class PacketInput extends PrimitiveInput {
         unmarshallable.unmarshalPreamble(this);
         unmarshallable.unmarshalEntity(this);
         unmarshallable.unmarshalDeferrals(this);
+        // TODO Align should be called, but can require resetting the packet counts
         return unmarshallable;
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/io/PacketOutput.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/PacketOutput.java
@@ -33,6 +33,7 @@ public class PacketOutput extends PrimitiveOutput {
         marshallable.marshalPreamble(this);
         marshallable.marshalEntity(this);
         marshallable.marshalDeferrals(this);
+        // TODO Align should be called, but can require resetting the packet counts
         return marshallable;
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/objects/RPC_UNICODE_STRING.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/RPC_UNICODE_STRING.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ */
+package com.rapid7.client.dcerpc.objects;
+
+import java.io.IOException;
+import java.util.Objects;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.io.ndr.Marshallable;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+
+/**
+ * Represents a UTF-16 encoded unicode string in dcerpc.
+ *
+ *      typedef struct _RPC_UNICODE_STRING {
+ *          unsigned short Length;
+ *          unsigned short MaximumLength;
+ *          [size_is(MaximumLength/2), length_is(Length/2)]
+ *          WCHAR* Buffer;
+ *      } RPC_UNICODE_STRING,
+ *      *PRPC_UNICODE_STRING;
+ *
+ * NOTE: This structure has purposely not been mapped 1-1 with the dcerpc struct.
+ * There is no practical reason for a client to access the Length, MaximumLength, or raw byte[] of this
+ * struct, and so this class only stores the UTF-16 Java String. Conversions are done during marshalling/unmarshalling.
+ *
+ * An RPC_UNICODE_STRING can be null terminated. However this is abstracted away from the client and is only
+ * used during marshalling or unmarshalling.
+ * You should not provide a null terminator to your String when marshalling this object, and should
+ * not expect one in return.
+ *
+ * Marshalling Usage:
+ *      String myValue = "some string";
+ *      RPC_UNICODE_STRING rpcUnicodeString = RPC_UNICODE_STRING.of(true, myValue);
+ *      packetOut.writeMarshallable(rpcUnicodeString);
+ * Unmarshalling Usage:
+ *      RPC_UNICODE_STRING rpcUnicodeString = RPC_UNICODE_STRING.of(true);
+ *      packetIn.readUnmarshallable(rpcUnicodeString);
+ *      String myValue = rpcUnicodeString.getValue();
+ */
+public abstract class RPC_UNICODE_STRING implements Unmarshallable, Marshallable {
+
+    /**
+     * Convenience method for construction of RPC_UNICODE_STRING.
+     * @param nullTerminated Whether or not the RPC_UNICODE_STRING is null terminated.
+     * @return A new RPC_UNICODE_STRING with an initial value of null.
+     */
+    public static RPC_UNICODE_STRING of(boolean nullTerminated) {
+        return (nullTerminated ? new NullTerminated() : new NotNullTerminated());
+    }
+
+    /**
+     * Convenience method for construction of RPC_UNICODE_STRING.
+     * @param nullTerminated Whether or not the RPC_UNICODE_STRING is null terminated.
+     * @param value The initial value of the RPC_UNICODE_STRING.
+     * @return A new RPC_UNICODE_STRING with the provided initial value.
+     */
+    public static RPC_UNICODE_STRING of(boolean nullTerminated, String value) {
+        RPC_UNICODE_STRING obj = of(nullTerminated);
+        obj.setValue(value);
+        return obj;
+    }
+
+    /**
+     * An RPC_UNICODE_STRING which is expected to be null terminated during marshalling/unmarshalling.
+     */
+    static class NullTerminated extends RPC_UNICODE_STRING {
+        @Override
+        boolean isNullTerminated() {
+            return true;
+        }
+    }
+
+    /**
+     * An RPC_UNICODE_STRING which is not expected to be null terminated during marshalling/unmarshalling.
+     */
+    static class NotNullTerminated extends RPC_UNICODE_STRING {
+        @Override
+        boolean isNullTerminated() {
+            return false;
+        }
+    }
+
+    private String value;
+
+    abstract boolean isNullTerminated();
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public Alignment getAlignment() {
+        /*
+         * unsigned short Length: 2
+         * unsigned short MaximumLength: 2
+         * [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer: 4
+         */
+        return Alignment.FOUR;
+    }
+
+    @Override
+    public void marshalPreamble(PacketOutput out) throws IOException {
+        // No preamble. Conformant array of `WCHAR*` is a reference, and so preamble is not required.
+    }
+
+    @Override
+    public void marshalEntity(PacketOutput out) throws IOException {
+        if (value == null) {
+            out.writeShort((short) 0);
+            out.writeShort((short) 0);
+            out.writeNull();
+        } else {
+            // UTF-16 encoded string is 2 bytes per count point
+            // Null terminator must also be considered
+            final int byteLength = 2 * value.length() + (isNullTerminated() ? 2 : 0);
+            out.writeShort((short) byteLength);
+            out.writeShort((short) byteLength);
+            out.writeReferentID();
+        }
+    }
+
+    @Override
+    public void marshalDeferrals(PacketOutput out) throws IOException {
+        if (value != null) {
+            final int codepoints = value.length() + (isNullTerminated() ? 1 : 0);
+            //Preamble
+            // MaximumCount for conformant array
+            out.writeInt(codepoints);
+
+            //Entity
+            // Offset for varying array
+            out.writeInt(0);
+            // ActualCount for varying array
+            out.writeInt(codepoints);
+
+            //Deferrals
+            // Entities for conformant+varying array
+            out.writeChars(value);
+            if (isNullTerminated())
+                out.writeShort((short) 0);
+            // Align the conformant+varying array
+            out.align(Alignment.FOUR);
+        }
+    }
+
+    @Override
+    public void unmarshalPreamble(PacketInput in) throws IOException {
+        // No preamble. Conformant array of `WCHAR*` is a reference, and so preamble is not required.
+    }
+
+    @Override
+    public void unmarshalEntity(PacketInput in) throws IOException {
+        in.readShort();
+        in.readShort();
+        if (in.readReferentID() != 0)
+            // This is 0 cost - Compile time constants are internal objects
+            value = "";
+    }
+
+    @Override
+    public void unmarshalDeferrals(PacketInput in) throws IOException {
+        if (value != null) {
+            //Preamble
+            // MaximumCount for conformant array - This is *not* the size of the array, so is not useful to us
+            in.readInt();
+
+            //Entity
+            // Offset for varying array
+            final int offset = in.readInt();
+            // ActualCount for varying array
+            final int actualCount = in.readInt();
+            // If we expect a null terminator, then skip it when reading the string
+            final int stringCount = (isNullTerminated() ? (actualCount - 1) : actualCount);
+
+            //Deferrals
+            // Entities for conformant array
+            final StringBuilder result = new StringBuilder(stringCount);
+            // Read prefix (if any)
+            for (int i = 0; i < offset; i++) {
+                in.readShort();
+            }
+            // Read subset
+            for (int i = 0; i < stringCount; i++) {
+                result.append((char) in.readShort());
+            }
+            // Read suffix (if any)
+            for (int i = stringCount; i < actualCount; i++) {
+                in.readShort();
+            }
+            // Align the conformant+varying array
+            in.align(Alignment.FOUR);
+            this.value = result.toString();
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isNullTerminated(), getValue());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (! (obj instanceof RPC_UNICODE_STRING)) {
+            return false;
+        }
+        RPC_UNICODE_STRING other = (RPC_UNICODE_STRING) obj;
+        return Objects.equals(isNullTerminated(), other.isNullTerminated())
+                && Objects.equals(getValue(), other.getValue());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("RPC_UNICODE_STRING{value:%s, nullTerminated:%b}",
+                getValue() == null ? "null" : String.format("\"%s\"", getValue()),
+                isNullTerminated());
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/objects/TEST_RPC_UNICODE_STRING.java
+++ b/src/test/java/com/rapid7/client/dcerpc/objects/TEST_RPC_UNICODE_STRING.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ */
+package com.rapid7.client.dcerpc.objects;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+
+public class TEST_RPC_UNICODE_STRING {
+
+    @DataProvider
+    public Object[][] data_of_null() {
+        return new Object[][] {
+                {false, RPC_UNICODE_STRING.NotNullTerminated.class},
+                {true, RPC_UNICODE_STRING.NullTerminated.class}
+        };
+    }
+
+    @Test(dataProvider = "data_of_null")
+    public void test_of_null(boolean nullTerminated, Class<?> clazz) {
+        RPC_UNICODE_STRING obj = RPC_UNICODE_STRING.of(nullTerminated);
+        assertEquals(obj.getClass(), clazz);
+        assertEquals(obj.isNullTerminated(), nullTerminated);
+        assertNull(obj.getValue());
+        assertEquals(obj.getAlignment(), Alignment.FOUR);
+    }
+
+    @DataProvider
+    public Object[][] data_of() {
+        return new Object[][] {
+                {false, null, RPC_UNICODE_STRING.NotNullTerminated.class},
+                {false, "test123", RPC_UNICODE_STRING.NotNullTerminated.class},
+                {true, null, RPC_UNICODE_STRING.NullTerminated.class},
+                {true, "test123", RPC_UNICODE_STRING.NullTerminated.class},
+        };
+    }
+
+    @Test(dataProvider = "data_of")
+    public void test_of(boolean nullTerminated, String value, Class<?> clazz) {
+        RPC_UNICODE_STRING obj = RPC_UNICODE_STRING.of(nullTerminated, value);
+        assertEquals(obj.getClass(), clazz);
+        assertEquals(obj.isNullTerminated(), nullTerminated);
+        assertEquals(obj.getValue(), value);
+        assertEquals(obj.getAlignment(), Alignment.FOUR);
+    }
+
+    @DataProvider
+    public Object[][] data_marshal_preamble() {
+        return new Object[][] {
+                {false, null},
+                {false, "test123"},
+                {true, null},
+                {true, "test123"},
+        };
+    }
+
+    @Test(dataProvider = "data_marshal_preamble")
+    public void test_marshal_preamble(boolean nullTerminated, String value) throws IOException {
+        RPC_UNICODE_STRING obj = RPC_UNICODE_STRING.of(nullTerminated, value);
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        obj.marshalPreamble(new PacketOutput(bout));
+        assertEquals(bout.toByteArray(), new byte[0]);
+    }
+
+    @DataProvider
+    public Object[][] data_marshal_entity() {
+        return new Object[][] {
+                {false, null, "0000000000000000"},
+                {true, null, "0000000000000000"},
+                {false, "testƟ123", "1000100000000200"},
+                {true, "testƟ123", "1200120000000200"},
+        };
+    }
+
+    @Test(dataProvider = "data_marshal_entity")
+    public void test_marshal_entity(boolean nullTerminated, String value, String expectedHex) throws IOException {
+        RPC_UNICODE_STRING obj = RPC_UNICODE_STRING.of(nullTerminated, value);
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        obj.marshalEntity(new PacketOutput(bout));
+        assertEquals(Hex.toHexString(bout.toByteArray()), expectedHex);
+    }
+
+    @DataProvider
+    public Object[][] data_marshal_deferrals() {
+        return new Object[][] {
+                {false, null, ""},
+                {true, null, ""},
+                {false, "testƟ123", "08000000000000000800000074006500730074009f01310032003300"},
+                {true, "testƟ123", "09000000000000000900000074006500730074009f013100320033000000"},
+        };
+    }
+
+    @Test(dataProvider = "data_marshal_deferrals")
+    public void test_marshal_deferrals(boolean nullTerminated, String value, String expectedHex) throws IOException {
+        RPC_UNICODE_STRING obj = RPC_UNICODE_STRING.of(nullTerminated, value);
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        obj.marshalDeferrals(new PacketOutput(bout));
+        assertEquals(Hex.toHexString(bout.toByteArray()), expectedHex);
+    }
+
+    @Test(dataProvider = "data_marshal_preamble")
+    public void test_unmarshal_preamble(boolean nullTerminated, String value) throws IOException {
+        RPC_UNICODE_STRING obj = RPC_UNICODE_STRING.of(nullTerminated, value);
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode("1a2e"));
+        obj.unmarshalPreamble(new PacketInput(bin));
+        assertEquals(bin.available(), 2);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshal_entity() {
+        return new Object[][] {
+                {false, "0000000000000000", null},
+                {true, "0000000000000000", null},
+                // We use an empty string as as placeholder to indicate the referent is non-null
+                {false, "1000100000000200", ""},
+                {true, "1000100000000200", ""}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshal_entity")
+    public void test_unmarshal_entity(boolean nullTerminated, String hex, String value) throws IOException {
+        RPC_UNICODE_STRING obj = RPC_UNICODE_STRING.of(nullTerminated);
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        obj.unmarshalEntity(in);
+        assertEquals(obj.isNullTerminated(), nullTerminated);
+        assertEquals(obj.getValue(), value);
+        assertEquals(bin.available(), 0);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshal_deferrals() {
+        return new Object[][] {
+                // not null terminated, no subset
+                {false, "08000000000000000800000074006500730074009f01310032003300", "testƟ123"},
+                // null terminated, no subset
+                {true, "09000000000000000900000074006500730074009f013100320033000000", "testƟ123"},
+                // not null terminated, lefthand subset MaximumCount=0, Offset=4, ActualCount=8 (testtestƟ123)
+                {false, "000000000400000008000000740065007300740074006500730074009f01310032003300", "testƟ123"},
+                // null terminated, lefthand subset MaximumCount=0, Offset=4, ActualCount=9 (testtestƟ123)
+                {true, "000000000400000009000000740065007300740074006500730074009f013100320033000000", "testƟ123"},
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshal_deferrals")
+    public void test_unmarshal_deferrals(boolean nullTerminated, String hex, String value) throws IOException {
+        RPC_UNICODE_STRING obj = RPC_UNICODE_STRING.of(nullTerminated);
+        // Value must be non-null for deferrals to read the ref
+        obj.setValue("");
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        obj.unmarshalDeferrals(in);
+        assertEquals(obj.isNullTerminated(), nullTerminated);
+        assertEquals(obj.getValue(), value);
+        assertEquals(bin.available(), 0);
+    }
+
+
+    @Test
+    public void test_hashCode_NotNullTerminated() {
+        RPC_UNICODE_STRING obj = RPC_UNICODE_STRING.of(false);
+        assertEquals(obj.hashCode(), 39308);
+        obj.setValue("testƟ123");
+        assertEquals(obj.hashCode(), -1136940719);
+    }
+
+    @Test
+    public void test_hashCode_NullTerminated() {
+        RPC_UNICODE_STRING obj = RPC_UNICODE_STRING.of(true);
+        assertEquals(obj.hashCode(), 39122);
+        obj.setValue("testƟ123");
+        assertEquals(obj.hashCode(), -1136940905);
+    }
+
+    @Test
+    public void test_equals() {
+        RPC_UNICODE_STRING obj_nt1 = RPC_UNICODE_STRING.of(true);
+        RPC_UNICODE_STRING obj_nt2 = RPC_UNICODE_STRING.of(true);
+        RPC_UNICODE_STRING obj_ntn1 = RPC_UNICODE_STRING.of(false);
+        RPC_UNICODE_STRING obj_ntn2 = RPC_UNICODE_STRING.of(false);
+        assertEquals(obj_nt1, obj_nt2);
+        assertEquals(obj_ntn1, obj_ntn2);
+        assertNotEquals(obj_nt1, obj_ntn1);
+        obj_nt2.setValue("test123");
+        obj_ntn2.setValue("test123");
+        assertNotEquals(obj_nt1, obj_nt2);
+        assertNotEquals(obj_ntn1, obj_ntn2);
+        obj_nt1.setValue("test123");
+        obj_ntn1.setValue("test123");
+        assertEquals(obj_nt1, obj_nt2);
+        assertEquals(obj_ntn1, obj_ntn2);
+    }
+
+    @DataProvider
+    public Object[][] data_toString() {
+        return new Object[][] {
+                {false, "test", "RPC_UNICODE_STRING{value:\"test\", nullTerminated:false}"},
+                {true, "test", "RPC_UNICODE_STRING{value:\"test\", nullTerminated:true}"},
+                {true, null, "RPC_UNICODE_STRING{value:null, nullTerminated:true}"}
+        };
+    }
+
+    @Test(dataProvider = "data_toString")
+    public void test_toString(boolean nullTerminated, String value, String expected) {
+        RPC_UNICODE_STRING str = RPC_UNICODE_STRING.of(nullTerminated, value);
+        assertEquals(str.toString(), expected);
+    }
+}


### PR DESCRIPTION
This is a replacement for PacketInput/PacketOutput string marshalling which only allows the string to be a top level deferral.
RPC_UNICODE_STRING allows the structure to be placed anywhere within a request stack.