### PR TITLE
Updating mvn dependencies so that TestNG will be executed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,16 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.3</version>
+            <version>3.7.0</version>
+            <configuration>
+               <source>${maven.compiler.source}</source>
+               <target>${maven.compiler.target}</target>
+            </configuration>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.20.1</version>
          </plugin>
          <plugin>
             <groupId>org.sonatype.plugins</groupId>
@@ -127,7 +136,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
+            <version>3.0.1</version>
             <executions>
                <execution>
                   <id>attach-sources</id>

--- a/src/test/java/com/rapid7/client/dcerpc/objects/Test_RPC_SID.java
+++ b/src/test/java/com/rapid7/client/dcerpc/objects/Test_RPC_SID.java
@@ -29,7 +29,7 @@ import com.rapid7.client.dcerpc.io.ndr.Alignment;
 
 import static org.testng.Assert.*;
 
-public class TEST_RPC_SID {
+public class Test_RPC_SID {
 
     @Test(expectedExceptions = {NullPointerException.class})
     public void test_marshalPreamble_null() throws IOException {

--- a/src/test/java/com/rapid7/client/dcerpc/objects/Test_RPC_UNICODE_STRING.java
+++ b/src/test/java/com/rapid7/client/dcerpc/objects/Test_RPC_UNICODE_STRING.java
@@ -33,7 +33,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 
-public class TEST_RPC_UNICODE_STRING {
+public class Test_RPC_UNICODE_STRING {
 
     @DataProvider
     public Object[][] data_of_null() {
@@ -112,8 +112,10 @@ public class TEST_RPC_UNICODE_STRING {
         return new Object[][] {
                 {false, null, ""},
                 {true, null, ""},
+                // MaximumCount=8, Offset=0, ActualCount=8, Alignment=0
                 {false, "testƟ123", "08000000000000000800000074006500730074009f01310032003300"},
-                {true, "testƟ123", "09000000000000000900000074006500730074009f013100320033000000"},
+                // MaximumCount=9, Offset=0, ActualCount=9, Alignment=2b
+                {true, "testƟ123", "09000000000000000900000074006500730074009f0131003200330000000000"},
         };
     }
 
@@ -158,14 +160,14 @@ public class TEST_RPC_UNICODE_STRING {
     @DataProvider
     public Object[][] data_unmarshal_deferrals() {
         return new Object[][] {
-                // not null terminated, no subset
+                // not null terminated, no subset, MaximumCount=8, Offset=8, ActualCount=8, Alignment=0b
                 {false, "08000000000000000800000074006500730074009f01310032003300", "testƟ123"},
-                // null terminated, no subset
-                {true, "09000000000000000900000074006500730074009f013100320033000000", "testƟ123"},
-                // not null terminated, lefthand subset MaximumCount=0, Offset=4, ActualCount=8 (testtestƟ123)
+                // null terminated, no subset, MaximumCount=9, Offset=0, ActualCount=9, Alignment=2b
+                {true, "09000000000000000900000074006500730074009f0131003200330000000000", "testƟ123"},
+                // not null terminated, lefthand subset MaximumCount=0, Offset=4, ActualCount=8, Alignment=0b(testtestƟ123)
                 {false, "000000000400000008000000740065007300740074006500730074009f01310032003300", "testƟ123"},
-                // null terminated, lefthand subset MaximumCount=0, Offset=4, ActualCount=9 (testtestƟ123)
-                {true, "000000000400000009000000740065007300740074006500730074009f013100320033000000", "testƟ123"},
+                // null terminated, lefthand subset MaximumCount=0, Offset=4, ActualCount=9, Alignment=2b (testtestƟ123)
+                {true, "000000000400000009000000740065007300740074006500730074009f0131003200330000000000", "testƟ123"},
         };
     }
 


### PR DESCRIPTION
We were previously using an older version of several maven dependencies which dependended on compile+test of Junit < 4.
However, JUnit >= 4 is required for TestNG to pick up on the tests. Relevant maven plugins have been updated.

- Fixing RPC_SID and RPC_UNICODE_STRING names to match TestNG pattern
- Fixing RPC_UNICODE_STRING tests broken by alignment
- Forcing source/target JDK 1.7