### PR TITLE
Adds LSAPR_POLICY_PRIMARY_DOM_INFO to LsarQueryInformationPolicy

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
@@ -26,6 +26,7 @@ import com.rapid7.client.dcerpc.RPCException;
 import com.rapid7.client.dcerpc.messages.HandleResponse;
 import com.rapid7.client.dcerpc.mslsad.messages.*;
 import com.rapid7.client.dcerpc.mslsad.objects.LSAPR_POLICY_AUDIT_EVENTS_INFO;
+import com.rapid7.client.dcerpc.mslsad.objects.LSAPR_POLICY_PRIMARY_DOM_INFO;
 import com.rapid7.client.dcerpc.objects.ContextHandle;
 import com.rapid7.client.dcerpc.transport.RPCTransport;
 
@@ -59,6 +60,12 @@ public class LocalSecurityAuthorityService {
     public LSAPR_POLICY_AUDIT_EVENTS_INFO getAuditPolicy(ContextHandle handle) throws IOException {
         checkHandle(handle);
         final LsarQueryInformationPolicyRequest.PolicyAuditEventsInformation queryRequest = new LsarQueryInformationPolicyRequest.PolicyAuditEventsInformation(handle);
+        return transport.call(queryRequest).getPolicyInformation();
+    }
+
+    public LSAPR_POLICY_PRIMARY_DOM_INFO getPolicyPrimaryDomainInformation(ContextHandle policyHandle) throws IOException {
+        checkHandle(policyHandle);
+        final LsarQueryInformationPolicyRequest.PolicyPrimaryDomainInformation queryRequest = new LsarQueryInformationPolicyRequest.PolicyPrimaryDomainInformation(policyHandle);
         return transport.call(queryRequest).getPolicyInformation();
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarQueryInformationPolicyRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarQueryInformationPolicyRequest.java
@@ -23,6 +23,7 @@ import com.rapid7.client.dcerpc.io.PacketOutput;
 import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
 import com.rapid7.client.dcerpc.messages.RequestCall;
 import com.rapid7.client.dcerpc.mslsad.objects.LSAPR_POLICY_AUDIT_EVENTS_INFO;
+import com.rapid7.client.dcerpc.mslsad.objects.LSAPR_POLICY_PRIMARY_DOM_INFO;
 import com.rapid7.client.dcerpc.mslsad.objects.POLICY_INFORMATION_CLASS;
 import com.rapid7.client.dcerpc.objects.ContextHandle;
 
@@ -52,7 +53,6 @@ public abstract class LsarQueryInformationPolicyRequest<T extends Unmarshallable
     }
 
     public static class PolicyAuditEventsInformation extends LsarQueryInformationPolicyRequest<LSAPR_POLICY_AUDIT_EVENTS_INFO> {
-
         public PolicyAuditEventsInformation(final ContextHandle policyHandle) {
             super(policyHandle, POLICY_INFORMATION_CLASS.POLICY_AUDIT_EVENTS_INFORMATION);
         }
@@ -60,6 +60,17 @@ public abstract class LsarQueryInformationPolicyRequest<T extends Unmarshallable
         @Override
         LSAPR_POLICY_AUDIT_EVENTS_INFO newPolicyInformation() {
             return new LSAPR_POLICY_AUDIT_EVENTS_INFO();
+        }
+    }
+
+    public static class PolicyPrimaryDomainInformation extends LsarQueryInformationPolicyRequest<LSAPR_POLICY_PRIMARY_DOM_INFO> {
+        public PolicyPrimaryDomainInformation(final ContextHandle policyHandle) {
+            super(policyHandle, POLICY_INFORMATION_CLASS.POLICY_PRIMARY_DOMAIN_INFORMATION);
+        }
+
+        @Override
+        LSAPR_POLICY_PRIMARY_DOM_INFO newPolicyInformation() {
+            return new LSAPR_POLICY_PRIMARY_DOM_INFO();
         }
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPR_POLICY_PRIMARY_DOM_INFO.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPR_POLICY_PRIMARY_DOM_INFO.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mslsad.objects;
+
+import java.io.IOException;
+import java.util.Objects;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+import com.rapid7.client.dcerpc.objects.RPC_SID;
+import com.rapid7.client.dcerpc.objects.RPC_UNICODE_STRING;
+
+/**
+ *  typedef struct _LSAPR_POLICY_PRIMARY_DOM_INFO {
+ *      RPC_UNICODE_STRING Name;
+ *      PRPC_SID Sid;
+ *  } LSAPR_POLICY_PRIMARY_DOM_INFO,
+ *  *PLSAPR_POLICY_PRIMARY_DOM_INFO;
+ */
+public class LSAPR_POLICY_PRIMARY_DOM_INFO implements Unmarshallable {
+
+    // <NDR: struct> RPC_UNICODE_STRING Name;
+    private RPC_UNICODE_STRING name;
+    // <NDR: *struct> PRPC_SID Sid;
+    private RPC_SID sid;
+
+    public RPC_UNICODE_STRING getName() {
+        return name;
+    }
+
+    public void setName(RPC_UNICODE_STRING name) {
+        this.name = name;
+    }
+
+    public RPC_SID getSid() {
+        return sid;
+    }
+
+    public void setSid(RPC_SID sid) {
+        this.sid = sid;
+    }
+
+    @Override
+    public Alignment getAlignment() {
+        // RPC_UNICODE_STRING: 4
+        // PRPC_SID: 4
+        return Alignment.FOUR;
+    }
+
+    @Override
+    public void unmarshalPreamble(PacketInput in) throws IOException {
+        name = RPC_UNICODE_STRING.of(false);
+        name.unmarshalPreamble(in);
+    }
+
+    @Override
+    public void unmarshalEntity(PacketInput in) throws IOException {
+        name.unmarshalEntity(in);
+        // RPC_UNICODE_STRING.unmarshalEntity reads exactly 4 bytes, no need for alignment
+        if (in.readReferentID() != 0) {
+            sid = new RPC_SID();
+        }
+    }
+
+    @Override
+    public void unmarshalDeferrals(PacketInput in) throws IOException {
+        name.unmarshalDeferrals(in);
+        // RPC_UNICODE_STRING.unmarshalDeferrals writes a variable number of bytes, align before continuing
+        if (sid != null) {
+            in.align(sid.getAlignment());
+            in.readUnmarshallable(sid);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getSid());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (! (obj instanceof LSAPR_POLICY_PRIMARY_DOM_INFO)) {
+            return false;
+        }
+        LSAPR_POLICY_PRIMARY_DOM_INFO other = (LSAPR_POLICY_PRIMARY_DOM_INFO) obj;
+        return Objects.equals(getName(), other.getName())
+                && Objects.equals(getSid(), other.getSid());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("LSAPR_POLICY_PRIMARY_DOM_INFO{Name:%s, Sid:%s}", getName(), getSid());
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/POLICY_INFORMATION_CLASS.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/POLICY_INFORMATION_CLASS.java
@@ -19,7 +19,8 @@
 package com.rapid7.client.dcerpc.mslsad.objects;
 
 public enum POLICY_INFORMATION_CLASS {
-    POLICY_AUDIT_EVENTS_INFORMATION(2);
+    POLICY_AUDIT_EVENTS_INFORMATION(2),
+    POLICY_PRIMARY_DOMAIN_INFORMATION(3);
 
     POLICY_INFORMATION_CLASS(final int infoLevel) {
         this.infoLevel = infoLevel;

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPR_POLICY_PRIMARY_DOM_INFO.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPR_POLICY_PRIMARY_DOM_INFO.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mslsad.objects;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.objects.RPC_SID;
+import com.rapid7.client.dcerpc.objects.RPC_UNICODE_STRING;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+public class Test_LSAPR_POLICY_PRIMARY_DOM_INFO {
+    @Test
+    public void test_getters_default() {
+        LSAPR_POLICY_PRIMARY_DOM_INFO obj = new LSAPR_POLICY_PRIMARY_DOM_INFO();
+        assertEquals(obj.getAlignment(), Alignment.FOUR);
+        assertNull(obj.getName());
+        assertNull(obj.getSid());
+    }
+
+    @Test
+    public void test_setters() {
+        LSAPR_POLICY_PRIMARY_DOM_INFO obj = new LSAPR_POLICY_PRIMARY_DOM_INFO();
+        RPC_UNICODE_STRING name = RPC_UNICODE_STRING.of(false, "test 123");
+        obj.setName(name);
+        RPC_SID sid = new RPC_SID();
+        obj.setSid(sid);
+        assertSame(obj.getName(), name);
+        assertSame(obj.getSid(), sid);
+    }
+
+    @Test
+    public void test_unmarshalPreamble() throws IOException {
+        LSAPR_POLICY_PRIMARY_DOM_INFO obj = new LSAPR_POLICY_PRIMARY_DOM_INFO();
+        assertNull(obj.getName());
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode("010203"));
+        obj.unmarshalPreamble(new PacketInput(bin));
+        assertEquals(obj.getName(), RPC_UNICODE_STRING.of(false));
+        assertEquals(bin.available(), 3);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshalEntity() {
+        return new Object[][] {
+                // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
+                {"0200 0300 01000000 00000000", RPC_UNICODE_STRING.of(false, ""), null},
+                // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
+                {"0200 0300 01000000 02000000", RPC_UNICODE_STRING.of(false, ""), new RPC_SID()},
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshalEntity")
+    public void test_unmarshalEntity(String hex, RPC_UNICODE_STRING expectedName, RPC_SID expectedSid) throws Exception {
+        LSAPR_POLICY_PRIMARY_DOM_INFO obj = new LSAPR_POLICY_PRIMARY_DOM_INFO();
+        obj.setName(RPC_UNICODE_STRING.of(false));
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        obj.unmarshalEntity(new PacketInput(bin));
+        assertEquals(bin.available(), 0);
+        assertEquals(obj.getName(), expectedName);
+        assertEquals(obj.getSid(), expectedSid);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshalDeferrals() {
+        RPC_UNICODE_STRING name1 = RPC_UNICODE_STRING.of(false, "test 123");
+        RPC_SID sid1 = new RPC_SID();
+        sid1.setRevision((char) 1);
+        sid1.setSubAuthorityCount((char) 4);
+        sid1.setIdentifierAuthority(new byte[]{0,0,0,0,0,5});
+        sid1.setSubAuthority(new long[]{1,2,3,4});
+        RPC_UNICODE_STRING name2 = RPC_UNICODE_STRING.of(false, "test 1234");
+        return new Object[][] {
+                // Name MaximumCount: 9, Offset: 0, ActualCount: 8, Value: "test 123"
+                // SID MaximumCount: 4, Revision: 1, SubAuthorityCount: 4, IdentifierAuthority:{0,0,0,0,0,5}, SubAuthority:{1,2,3,4}
+                {"09000000 00000000 08000000 7400 6500 7300 7400 2000 3100 3200 3300"
+                + "04000000 01 04 000000000005 01000000 02000000 03000000 04000000",
+                new RPC_SID(), name1, sid1},
+                // Test Alignment:
+                // Name MaximumCount: 9, Offset: 0, ActualCount: 9, Value: "test 1234"
+                // SID MaximumCount: 4, Revision: 1, SubAuthorityCount: 4, IdentifierAuthority:{0,0,0,0,0,5}, SubAuthority:{1,2,3,4}
+                {"09000000 00000000 09000000 7400 6500 7300 7400 2000 3100 3200 3300 3400 0000"
+                + "04000000 01 04 000000000005 01000000 02000000 03000000 04000000",
+                new RPC_SID(), name2, sid1},
+                // Test null sid pointer:
+                // Name MaximumCount: 9, Offset: 0, ActualCount: 8, Value: "test 123"
+                {"09000000 00000000 08000000 7400 6500 7300 7400 2000 3100 3200 3300",
+                null, name1, null},
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshalDeferrals")
+    public void test_unmarshalDeferrals(String hex, RPC_SID sid, RPC_UNICODE_STRING expectedName, RPC_SID expectedSid) throws Exception {
+        LSAPR_POLICY_PRIMARY_DOM_INFO obj = new LSAPR_POLICY_PRIMARY_DOM_INFO();
+        obj.setName(RPC_UNICODE_STRING.of(false, ""));
+        obj.setSid(sid);
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        obj.unmarshalDeferrals(new PacketInput(bin));
+        assertEquals(bin.available(), 0);
+        assertEquals(obj.getName(), expectedName);
+        assertEquals(obj.getSid(), expectedSid);
+    }
+
+    @Test
+    public void test_toString_default() {
+        LSAPR_POLICY_PRIMARY_DOM_INFO obj = new LSAPR_POLICY_PRIMARY_DOM_INFO();
+        assertEquals(obj.toString(), "LSAPR_POLICY_PRIMARY_DOM_INFO{Name:null, Sid:null}");
+    }
+
+    @Test
+    public void test_toString() {
+        LSAPR_POLICY_PRIMARY_DOM_INFO obj = new LSAPR_POLICY_PRIMARY_DOM_INFO();
+        obj.setName(RPC_UNICODE_STRING.of(false, "test 123"));
+        RPC_SID sid = new RPC_SID();
+        sid.setRevision((char) 1);
+        sid.setSubAuthorityCount((char) 4);
+        sid.setIdentifierAuthority(new byte[]{1, 2, 3, 4, 5, 6});
+        sid.setSubAuthority(new long[]{1, 2, 3});
+        obj.setSid(sid);
+        assertEquals(obj.toString(), "LSAPR_POLICY_PRIMARY_DOM_INFO{Name:RPC_UNICODE_STRING{value:\"test 123\", nullTerminated:false}, Sid:RPC_SID{Revision:1, SubAuthorityCount:4, IdentifierAuthority:[1, 2, 3, 4, 5, 6], SubAuthority: [1, 2, 3]}}");
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_POLICY_INFORMATION_CLASS.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_POLICY_INFORMATION_CLASS.java
@@ -28,7 +28,8 @@ public class Test_POLICY_INFORMATION_CLASS {
     @DataProvider
     public Object[][] data_getInfoLevel() {
         return new Object[][] {
-                {POLICY_INFORMATION_CLASS.POLICY_AUDIT_EVENTS_INFORMATION, (short) 2}
+                {POLICY_INFORMATION_CLASS.POLICY_AUDIT_EVENTS_INFORMATION, (short) 2},
+                {POLICY_INFORMATION_CLASS.POLICY_PRIMARY_DOMAIN_INFORMATION, (short) 3}
         };
     }
     @Test(dataProvider = "data_getInfoLevel")


### PR DESCRIPTION
- Adding LSAPR_POLICY_PRIMARY_DOM_INFO struct
- Adding POLICY_PRIMARY_DOMAIN_INFORMATION to POLICY_INFORMATION_CLASS enum
- Mapping POLICY_PRIMARY_DOMAIN_INFORMATION to LSAPR_POLICY_PRIMARY_DOM_INFO via LsarQueryInformationPolicyRequest.PolicyPrimaryDomainInformation
- Adding getPolicyPrimaryDomainInformation to LocalSecurityAuthorityService