### PR TITLE
Adds LSAPR_POLICY_ACCOUNT_DOM_INFO to LsarQueryInformationPolicy

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
@@ -25,6 +25,7 @@ import com.hierynomus.msdtyp.SID;
 import com.rapid7.client.dcerpc.RPCException;
 import com.rapid7.client.dcerpc.messages.HandleResponse;
 import com.rapid7.client.dcerpc.mslsad.messages.*;
+import com.rapid7.client.dcerpc.mslsad.objects.LSAPR_POLICY_ACCOUNT_DOM_INFO;
 import com.rapid7.client.dcerpc.mslsad.objects.LSAPR_POLICY_AUDIT_EVENTS_INFO;
 import com.rapid7.client.dcerpc.mslsad.objects.LSAPR_POLICY_PRIMARY_DOM_INFO;
 import com.rapid7.client.dcerpc.objects.ContextHandle;
@@ -66,6 +67,12 @@ public class LocalSecurityAuthorityService {
     public LSAPR_POLICY_PRIMARY_DOM_INFO getPolicyPrimaryDomainInformation(ContextHandle policyHandle) throws IOException {
         checkHandle(policyHandle);
         final LsarQueryInformationPolicyRequest.PolicyPrimaryDomainInformation queryRequest = new LsarQueryInformationPolicyRequest.PolicyPrimaryDomainInformation(policyHandle);
+        return transport.call(queryRequest).getPolicyInformation();
+    }
+
+    public LSAPR_POLICY_ACCOUNT_DOM_INFO getPolicyAccountDomainInformation(ContextHandle policyHandle) throws IOException {
+        checkHandle(policyHandle);
+        final LsarQueryInformationPolicyRequest.PolicyAccountDomainInformation queryRequest = new LsarQueryInformationPolicyRequest.PolicyAccountDomainInformation(policyHandle);
         return transport.call(queryRequest).getPolicyInformation();
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarQueryInformationPolicyRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarQueryInformationPolicyRequest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import com.rapid7.client.dcerpc.io.PacketOutput;
 import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
 import com.rapid7.client.dcerpc.messages.RequestCall;
+import com.rapid7.client.dcerpc.mslsad.objects.LSAPR_POLICY_ACCOUNT_DOM_INFO;
 import com.rapid7.client.dcerpc.mslsad.objects.LSAPR_POLICY_AUDIT_EVENTS_INFO;
 import com.rapid7.client.dcerpc.mslsad.objects.LSAPR_POLICY_PRIMARY_DOM_INFO;
 import com.rapid7.client.dcerpc.mslsad.objects.POLICY_INFORMATION_CLASS;
@@ -71,6 +72,17 @@ public abstract class LsarQueryInformationPolicyRequest<T extends Unmarshallable
         @Override
         LSAPR_POLICY_PRIMARY_DOM_INFO newPolicyInformation() {
             return new LSAPR_POLICY_PRIMARY_DOM_INFO();
+        }
+    }
+
+    public static class PolicyAccountDomainInformation extends LsarQueryInformationPolicyRequest<LSAPR_POLICY_ACCOUNT_DOM_INFO> {
+        public PolicyAccountDomainInformation(final ContextHandle policyHandle) {
+            super(policyHandle, POLICY_INFORMATION_CLASS.POLICY_ACCOUNT_DOMAIN_INFORMATION);
+        }
+
+        @Override
+        LSAPR_POLICY_ACCOUNT_DOM_INFO newPolicyInformation() {
+            return new LSAPR_POLICY_ACCOUNT_DOM_INFO();
         }
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPR_POLICY_ACCOUNT_DOM_INFO.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPR_POLICY_ACCOUNT_DOM_INFO.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mslsad.objects;
+
+import java.io.IOException;
+import java.util.Objects;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+import com.rapid7.client.dcerpc.objects.RPC_SID;
+import com.rapid7.client.dcerpc.objects.RPC_UNICODE_STRING;
+
+/**
+ *  typedef struct _LSAPR_POLICY_ACCOUNT_DOM_INFO {
+ *      RPC_UNICODE_STRING DomainName;
+ *      PRPC_SID DomainSid;
+ *  } LSAPR_POLICY_ACCOUNT_DOM_INFO,
+ *  *PLSAPR_POLICY_ACCOUNT_DOM_INFO;
+ *
+ */
+public class LSAPR_POLICY_ACCOUNT_DOM_INFO implements Unmarshallable {
+
+    // <NDR: struct> RPC_UNICODE_STRING DomainName;
+    private RPC_UNICODE_STRING domainName;
+    // <NDR: *struct> PRPC_SID DomainSid;
+    private RPC_SID domainSid;
+
+    public RPC_UNICODE_STRING getDomainName() {
+        return domainName;
+    }
+
+    public void setDomainName(RPC_UNICODE_STRING domainName) {
+        this.domainName = domainName;
+    }
+
+    public RPC_SID getDomainSid() {
+        return domainSid;
+    }
+
+    public void setDomainSid(RPC_SID domainSid) {
+        this.domainSid = domainSid;
+    }
+
+    @Override
+    public Alignment getAlignment() {
+        // RPC_UNICODE_STRING: 4
+        // PRPC_SID: 4
+        return Alignment.FOUR;
+    }
+
+    @Override
+    public void unmarshalPreamble(PacketInput in) throws IOException {
+        domainName = RPC_UNICODE_STRING.of(false);
+        domainName.unmarshalPreamble(in);
+    }
+
+    @Override
+    public void unmarshalEntity(PacketInput in) throws IOException {
+        domainName.unmarshalEntity(in);
+        // RPC_UNICODE_STRING.unmarshalEntity reads exactly 4 bytes, no need for alignment
+        if (in.readReferentID() != 0) {
+            domainSid = new RPC_SID();
+        }
+    }
+
+    @Override
+    public void unmarshalDeferrals(PacketInput in) throws IOException {
+        domainName.unmarshalDeferrals(in);
+        // RPC_UNICODE_STRING.unmarshalDeferrals writes a variable number of bytes, align before continuing
+        if (domainSid != null) {
+            in.align(domainSid.getAlignment());
+            in.readUnmarshallable(domainSid);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getDomainName(), getDomainSid());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (! (obj instanceof LSAPR_POLICY_ACCOUNT_DOM_INFO)) {
+            return false;
+        }
+        LSAPR_POLICY_ACCOUNT_DOM_INFO other = (LSAPR_POLICY_ACCOUNT_DOM_INFO) obj;
+        return Objects.equals(getDomainName(), other.getDomainName())
+                && Objects.equals(getDomainSid(), other.getDomainSid());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("LSAPR_POLICY_ACCOUNT_DOM_INFO{DomainName:%s, DomainSid:%s}", getDomainName(), getDomainSid());
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/POLICY_INFORMATION_CLASS.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/POLICY_INFORMATION_CLASS.java
@@ -20,7 +20,8 @@ package com.rapid7.client.dcerpc.mslsad.objects;
 
 public enum POLICY_INFORMATION_CLASS {
     POLICY_AUDIT_EVENTS_INFORMATION(2),
-    POLICY_PRIMARY_DOMAIN_INFORMATION(3);
+    POLICY_PRIMARY_DOMAIN_INFORMATION(3),
+    POLICY_ACCOUNT_DOMAIN_INFORMATION(5);
 
     POLICY_INFORMATION_CLASS(final int infoLevel) {
         this.infoLevel = infoLevel;

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/messages/Test_LsarQueryInformationPolicyResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/messages/Test_LsarQueryInformationPolicyResponse.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mslsad.messages;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+import com.rapid7.client.dcerpc.mslsad.objects.POLICY_INFORMATION_CLASS;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+
+public class Test_LsarQueryInformationPolicyResponse {
+
+    @Test
+    public void test_getters() {
+        Unmarshallable obj = mock(Unmarshallable.class);
+        LsarQueryInformationPolicyResponse<Unmarshallable> response = new LsarQueryInformationPolicyResponse<>(obj, POLICY_INFORMATION_CLASS.POLICY_ACCOUNT_DOMAIN_INFORMATION);
+        assertSame(response.getPolicyInformation(), obj);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshal() {
+        return new Object[][] {
+                // Reference: 1, POLICY_CLASS_INFORMATION: 3
+                {"01000000 0300", Alignment.ONE},
+                // Reference: 1, POLICY_CLASS_INFORMATION: 3
+                {"01000000 0300", Alignment.TWO},
+                // Test alignments:
+                // Reference: 1, POLICY_CLASS_INFORMATION: 3, alignment: 2b
+                {"01000000 0300 0000", Alignment.FOUR},
+                // Reference: 1, POLICY_CLASS_INFORMATION: 3, alignment: 2b
+                {"01000000 0300 0000", Alignment.EIGHT}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshal")
+    public void test_unmarshal(String hex, Alignment alignment) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        Unmarshallable unmarshallable = mock(Unmarshallable.class);
+        when(unmarshallable.getAlignment()).thenReturn(alignment);
+        doNothing().when(unmarshallable).unmarshalPreamble(in);
+        doNothing().when(unmarshallable).unmarshalEntity(in);
+        doNothing().when(unmarshallable).unmarshalDeferrals(in);
+        LsarQueryInformationPolicyResponse<Unmarshallable> response = new LsarQueryInformationPolicyResponse<>(
+                unmarshallable,
+                POLICY_INFORMATION_CLASS.POLICY_PRIMARY_DOMAIN_INFORMATION);
+        response.unmarshal(in);
+        assertEquals(bin.available(), 0);
+    }
+
+    @Test
+    public void test_unmarshal_NullPointer() throws IOException {
+        // Reference: 0
+        String hex = "00000000";
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        LsarQueryInformationPolicyResponse<Unmarshallable> response = new LsarQueryInformationPolicyResponse<>(
+                null,
+                POLICY_INFORMATION_CLASS.POLICY_ACCOUNT_DOMAIN_INFORMATION);
+        response.unmarshal(in);
+        assertEquals(bin.available(), 0);
+    }
+
+    @Test
+    public void test_unmarshal_InvalidTag() throws IOException {
+        // Reference: 1, POLICY_CLASS_INFORMATION: 3
+        String hex = "01000000 0300";
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        LsarQueryInformationPolicyResponse<Unmarshallable> response = new LsarQueryInformationPolicyResponse<>(
+                null,
+                POLICY_INFORMATION_CLASS.POLICY_ACCOUNT_DOMAIN_INFORMATION);
+        IllegalArgumentException actual = null;
+        try {
+            response.unmarshal(in);
+        } catch (IllegalArgumentException e) {
+            actual = e;
+        }
+        assertNotNull(actual);
+        assertEquals(actual.getMessage(), "Incoming POLICY_INFORMATION_CLASS 3 does not match expected: 5");
+        assertEquals(bin.available(), 0);
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPR_POLICY_ACCOUNT_DOM_INFO.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPR_POLICY_ACCOUNT_DOM_INFO.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mslsad.objects;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.objects.RPC_SID;
+import com.rapid7.client.dcerpc.objects.RPC_UNICODE_STRING;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+public class Test_LSAPR_POLICY_ACCOUNT_DOM_INFO {
+    @Test
+    public void test_getters_default() {
+        LSAPR_POLICY_ACCOUNT_DOM_INFO obj = new LSAPR_POLICY_ACCOUNT_DOM_INFO();
+        assertEquals(obj.getAlignment(), Alignment.FOUR);
+        assertNull(obj.getDomainName());
+        assertNull(obj.getDomainSid());
+    }
+
+    @Test
+    public void test_setters() {
+        LSAPR_POLICY_ACCOUNT_DOM_INFO obj = new LSAPR_POLICY_ACCOUNT_DOM_INFO();
+        RPC_UNICODE_STRING name = RPC_UNICODE_STRING.of(false, "test 123");
+        obj.setDomainName(name);
+        RPC_SID sid = new RPC_SID();
+        obj.setDomainSid(sid);
+        assertSame(obj.getDomainName(), name);
+        assertSame(obj.getDomainSid(), sid);
+    }
+
+    @Test
+    public void test_unmarshalPreamble() throws IOException {
+        LSAPR_POLICY_ACCOUNT_DOM_INFO obj = new LSAPR_POLICY_ACCOUNT_DOM_INFO();
+        assertNull(obj.getDomainName());
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode("010203"));
+        obj.unmarshalPreamble(new PacketInput(bin));
+        assertEquals(obj.getDomainName(), RPC_UNICODE_STRING.of(false));
+        assertEquals(bin.available(), 3);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshalEntity() {
+        return new Object[][] {
+                // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
+                {"0200 0300 01000000 00000000", RPC_UNICODE_STRING.of(false, ""), null},
+                // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
+                {"0200 0300 01000000 02000000", RPC_UNICODE_STRING.of(false, ""), new RPC_SID()},
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshalEntity")
+    public void test_unmarshalEntity(String hex, RPC_UNICODE_STRING expectedName, RPC_SID expectedSid) throws Exception {
+        LSAPR_POLICY_ACCOUNT_DOM_INFO obj = new LSAPR_POLICY_ACCOUNT_DOM_INFO();
+        obj.setDomainName(RPC_UNICODE_STRING.of(false));
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        obj.unmarshalEntity(new PacketInput(bin));
+        assertEquals(bin.available(), 0);
+        assertEquals(obj.getDomainName(), expectedName);
+        assertEquals(obj.getDomainSid(), expectedSid);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshalDeferrals() {
+        RPC_UNICODE_STRING name1 = RPC_UNICODE_STRING.of(false, "test 123");
+        RPC_SID sid1 = new RPC_SID();
+        sid1.setRevision((char) 1);
+        sid1.setSubAuthorityCount((char) 4);
+        sid1.setIdentifierAuthority(new byte[]{0,0,0,0,0,5});
+        sid1.setSubAuthority(new long[]{1,2,3,4});
+        RPC_UNICODE_STRING name2 = RPC_UNICODE_STRING.of(false, "test 1234");
+        return new Object[][] {
+                // Name MaximumCount: 9, Offset: 0, ActualCount: 8, Value: "test 123"
+                // SID MaximumCount: 4, Revision: 1, SubAuthorityCount: 4, IdentifierAuthority:{0,0,0,0,0,5}, SubAuthority:{1,2,3,4}
+                {"09000000 00000000 08000000 7400 6500 7300 7400 2000 3100 3200 3300"
+                + "04000000 01 04 000000000005 01000000 02000000 03000000 04000000",
+                new RPC_SID(), name1, sid1},
+                // Test Alignment:
+                // Name MaximumCount: 9, Offset: 0, ActualCount: 9, Value: "test 1234"
+                // SID MaximumCount: 4, Revision: 1, SubAuthorityCount: 4, IdentifierAuthority:{0,0,0,0,0,5}, SubAuthority:{1,2,3,4}
+                {"09000000 00000000 09000000 7400 6500 7300 7400 2000 3100 3200 3300 3400 0000"
+                + "04000000 01 04 000000000005 01000000 02000000 03000000 04000000",
+                new RPC_SID(), name2, sid1},
+                // Test null sid pointer:
+                // Name MaximumCount: 9, Offset: 0, ActualCount: 8, Value: "test 123"
+                {"09000000 00000000 08000000 7400 6500 7300 7400 2000 3100 3200 3300",
+                null, name1, null},
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshalDeferrals")
+    public void test_unmarshalDeferrals(String hex, RPC_SID sid, RPC_UNICODE_STRING expectedName, RPC_SID expectedSid) throws Exception {
+        LSAPR_POLICY_ACCOUNT_DOM_INFO obj = new LSAPR_POLICY_ACCOUNT_DOM_INFO();
+        obj.setDomainName(RPC_UNICODE_STRING.of(false, ""));
+        obj.setDomainSid(sid);
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        obj.unmarshalDeferrals(new PacketInput(bin));
+        assertEquals(bin.available(), 0);
+        assertEquals(obj.getDomainName(), expectedName);
+        assertEquals(obj.getDomainSid(), expectedSid);
+    }
+
+    @Test
+    public void test_toString_default() {
+        LSAPR_POLICY_ACCOUNT_DOM_INFO obj = new LSAPR_POLICY_ACCOUNT_DOM_INFO();
+        assertEquals(obj.toString(), "LSAPR_POLICY_ACCOUNT_DOM_INFO{DomainName:null, DomainSid:null}");
+    }
+
+    @Test
+    public void test_toString() {
+        LSAPR_POLICY_ACCOUNT_DOM_INFO obj = new LSAPR_POLICY_ACCOUNT_DOM_INFO();
+        obj.setDomainName(RPC_UNICODE_STRING.of(false, "test 123"));
+        RPC_SID sid = new RPC_SID();
+        sid.setRevision((char) 1);
+        sid.setSubAuthorityCount((char) 4);
+        sid.setIdentifierAuthority(new byte[]{1, 2, 3, 4, 5, 6});
+        sid.setSubAuthority(new long[]{1, 2, 3});
+        obj.setDomainSid(sid);
+        assertEquals(obj.toString(), "LSAPR_POLICY_ACCOUNT_DOM_INFO{DomainName:RPC_UNICODE_STRING{value:\"test 123\", nullTerminated:false}, DomainSid:RPC_SID{Revision:1, SubAuthorityCount:4, IdentifierAuthority:[1, 2, 3, 4, 5, 6], SubAuthority: [1, 2, 3]}}");
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_POLICY_INFORMATION_CLASS.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_POLICY_INFORMATION_CLASS.java
@@ -29,7 +29,8 @@ public class Test_POLICY_INFORMATION_CLASS {
     public Object[][] data_getInfoLevel() {
         return new Object[][] {
                 {POLICY_INFORMATION_CLASS.POLICY_AUDIT_EVENTS_INFORMATION, (short) 2},
-                {POLICY_INFORMATION_CLASS.POLICY_PRIMARY_DOMAIN_INFORMATION, (short) 3}
+                {POLICY_INFORMATION_CLASS.POLICY_PRIMARY_DOMAIN_INFORMATION, (short) 3},
+                {POLICY_INFORMATION_CLASS.POLICY_ACCOUNT_DOMAIN_INFORMATION, (short) 5}
         };
     }
     @Test(dataProvider = "data_getInfoLevel")


### PR DESCRIPTION
* Adding LSAPR_POLICY_ACCOUNT_DOM_INFO struct
* Adding POLICY_ACCOUNT_DOMAIN_INFORMATION to POLICY_INFORMATION_CLASS enum
* Mapping POLICY_ACCOUNT_DOMAIN_INFORMATION to LSAPR_POLICY_ACCOUNT_DOM_INFO via LsarQueryInformationPolicyRequest.PolicyAccountDomainInformation
* Adding getPolicyAccountDomainInformation to LocalSecurityAuthorityService
* Adding unit tests for LsarQueryInformationPolicyResponse