### PR TITLE
Introducing new alignment strategy

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/io/PrimitiveOutput.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/PrimitiveOutput.java
@@ -44,13 +44,17 @@ public class PrimitiveOutput {
     public void align(Alignment alignment) throws IOException {
         if (alignment == Alignment.ONE) return;
         final long alignmentOffset = alignment.getOffByOneAlignment() + dataOutStream.getCount() & ~alignment.getOffByOneAlignment();
-        while (alignmentOffset > dataOutStream.getCount()) {
-            writeByte(0);
-        }
+        pad(alignmentOffset - dataOutStream.getCount());
     }
 
     public long getCount() {
         return dataOutStream.getCount();
+    }
+
+    public void pad(long n) throws IOException {
+        while (n-- > 0) {
+            writeByte(0);
+        }
     }
 
     public void write(final int b) throws IOException {

--- a/src/main/java/com/rapid7/client/dcerpc/io/ndr/DataType.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/ndr/DataType.java
@@ -46,48 +46,5 @@ package com.rapid7.client.dcerpc.io.ndr;
  *     * unsigned double
  */
 public interface DataType {
-    /**
-     * All NDR data types are aligned to a static value based on factors unique to the type.
-     *
-     * Primitives:
-     * NDR enforces NDR alignment of primitive data; that is, any primitive of size n octets is aligned
-     * at a octet stream index that is a multiple of n. (In this version of NDR, n is one of {1, 2, 4, 8}.)
-     * An octet stream index indicates the number of an octet in an octet stream when octets are numbered,
-     * beginning with 0, from the first octet in the stream. Where necessary, an alignment gap,
-     * consisting of octets of unspecified value, precedes the representation of a primitive.
-     * The gap is of the smallest size sufficient to align the primitive.
-     *
-     * Constructs:
-     * NDR enforces NDR alignment of structured data. As with primitive data types, an alignment, n,
-     * is determined for the structure. Where necessary, an alignment gap of octets of unspecified value precedes
-     * the data in the NDR octet stream. This gap is the smallest size sufficient to align the first field of the
-     * structure on an NDR octet stream index of n.
-     * The rules for calculating the alignment of constructed types are as follows:
-     *    * If a conformant structure-that is, a conformant or conformant varying array,
-     *    or a structure containing a conformant or conformant varying array-is embedded in the constructed type,
-     *    and is the outermost structure-that is, is not contained in another structure-then the size information
-     *    from the contained conformant structure is positioned so that it precedes both the containing constructed
-     *    type and any alignment gap for the constructed type. (See Structures Containing Arrays for information
-     *    about structures containing arrays.) The size information is itself aligned according to the alignment
-     *    rules for primitive data types. (See Alignment of Primitive Types .) The data of the constructed type is
-     *    then aligned according to the alignment rules for the constructed type. In other words, the size information
-     *    precedes the structure and is aligned independently of the structure alignment.
-     *    * The alignment of a structure in the octet stream is the largest of the alignments of the fields it contains.
-     *    These fields may also be constructed types. The same alignment rules apply recursively to nested constructed types.
-     *    The fields within the structure are aligned according to the following rules:
-     *    * Scalar primitives are aligned according to the rules in Alignment of Primitive Types .
-     *    * Pointer alignment is always modulo 4.
-     *    * Structure alignment is determined by recursive application of these rules.
-     *    * Array alignment is the largest alignment of the array element type and the size information type, if any.
-     *    * Union alignment is the largest alignment of the union discriminator and all of the union arms.
-     *
-     * The above definitions of union alignment and array alignment apply only to the calculation the NDR alignment
-     * of a structure and do not apply to the actual NDR alignment of a union or an array.
-     * For example, the NDR alignment of a union is determined by the tag type and the arm actually to be transmitted,
-     * not the largest of the union arms. Similarly, the NDR alignment of an array is determined by the element type
-     * alignment, which would be the largest arm of the union in the case of an array of unions.
-     *
-     * @return The alignment of the NDR type.
-     */
-    Alignment getAlignment();
+
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarQueryInformationPolicyResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarQueryInformationPolicyResponse.java
@@ -47,8 +47,6 @@ public class LsarQueryInformationPolicyResponse<T extends Unmarshallable> extend
                         "Incoming POLICY_INFORMATION_CLASS %d does not match expected: %d",
                         infoLevel, this.policyInformationClass.getInfoLevel()));
             }
-            // Alignment for structure - It's of unknown size so ask it what its alignment is
-            packetIn.align(this.policyInformation.getAlignment());
             packetIn.readUnmarshallable(this.policyInformation);
         }
     }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPR_POLICY_ACCOUNT_DOM_INFO.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPR_POLICY_ACCOUNT_DOM_INFO.java
@@ -30,18 +30,23 @@ import com.rapid7.client.dcerpc.objects.RPC_SID;
 import com.rapid7.client.dcerpc.objects.RPC_UNICODE_STRING;
 
 /**
- *  typedef struct _LSAPR_POLICY_ACCOUNT_DOM_INFO {
- *      RPC_UNICODE_STRING DomainName;
- *      PRPC_SID DomainSid;
- *  } LSAPR_POLICY_ACCOUNT_DOM_INFO,
- *  *PLSAPR_POLICY_ACCOUNT_DOM_INFO;
- *
+ * Structure: LSAPR_POLICY_ACCOUNT_DOM_INFO
+ * <pre>
+ *      typedef struct _LSAPR_POLICY_ACCOUNT_DOM_INFO {
+ *          RPC_UNICODE_STRING DomainName;
+ *          PRPC_SID DomainSid;
+ *      } LSAPR_POLICY_ACCOUNT_DOM_INFO,
+ *      *PLSAPR_POLICY_ACCOUNT_DOM_INFO;
+ * </pre>
+ * Alignment: 4 (Max[4,4])
+ *      RPC_UNICODE_STRING DomainName;: 4
+ *      PRPC_SID DomainSid;: 4
  */
 public class LSAPR_POLICY_ACCOUNT_DOM_INFO implements Unmarshallable {
 
     // <NDR: struct> RPC_UNICODE_STRING DomainName;
     private RPC_UNICODE_STRING domainName;
-    // <NDR: *struct> PRPC_SID DomainSid;
+    // <NDR: pointer> PRPC_SID DomainSid;
     private RPC_SID domainSid;
 
     public RPC_UNICODE_STRING getDomainName() {
@@ -61,13 +66,6 @@ public class LSAPR_POLICY_ACCOUNT_DOM_INFO implements Unmarshallable {
     }
 
     @Override
-    public Alignment getAlignment() {
-        // RPC_UNICODE_STRING: 4
-        // PRPC_SID: 4
-        return Alignment.FOUR;
-    }
-
-    @Override
     public void unmarshalPreamble(PacketInput in) throws IOException {
         domainName = RPC_UNICODE_STRING.of(false);
         domainName.unmarshalPreamble(in);
@@ -75,8 +73,12 @@ public class LSAPR_POLICY_ACCOUNT_DOM_INFO implements Unmarshallable {
 
     @Override
     public void unmarshalEntity(PacketInput in) throws IOException {
+        // Structure Alignment: 4
+        in.align(Alignment.FOUR);
+        // <NDR: struct> RPC_UNICODE_STRING DomainName;
         domainName.unmarshalEntity(in);
-        // RPC_UNICODE_STRING.unmarshalEntity reads exactly 4 bytes, no need for alignment
+        // <NDR: pointer> PRPC_SID DomainSid;
+        // Alignment: 4 - Already aligned
         if (in.readReferentID() != 0) {
             domainSid = new RPC_SID();
         }
@@ -85,9 +87,8 @@ public class LSAPR_POLICY_ACCOUNT_DOM_INFO implements Unmarshallable {
     @Override
     public void unmarshalDeferrals(PacketInput in) throws IOException {
         domainName.unmarshalDeferrals(in);
-        // RPC_UNICODE_STRING.unmarshalDeferrals writes a variable number of bytes, align before continuing
         if (domainSid != null) {
-            in.align(domainSid.getAlignment());
+            // <NDR: struct> RPC_SID DomainSid;
             in.readUnmarshallable(domainSid);
         }
     }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPR_POLICY_PRIMARY_DOM_INFO.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPR_POLICY_PRIMARY_DOM_INFO.java
@@ -30,17 +30,22 @@ import com.rapid7.client.dcerpc.objects.RPC_SID;
 import com.rapid7.client.dcerpc.objects.RPC_UNICODE_STRING;
 
 /**
+ * Structure: LSAPR_POLICY_PRIMARY_DOM_INFO
  *  typedef struct _LSAPR_POLICY_PRIMARY_DOM_INFO {
  *      RPC_UNICODE_STRING Name;
  *      PRPC_SID Sid;
  *  } LSAPR_POLICY_PRIMARY_DOM_INFO,
  *  *PLSAPR_POLICY_PRIMARY_DOM_INFO;
+ *
+ * Alignment: 4 (Max[4,4])
+ *      RPC_UNICODE_STRING Name;: 4
+ *      PRPC_SID Sid;: 4
  */
 public class LSAPR_POLICY_PRIMARY_DOM_INFO implements Unmarshallable {
 
     // <NDR: struct> RPC_UNICODE_STRING Name;
     private RPC_UNICODE_STRING name;
-    // <NDR: *struct> PRPC_SID Sid;
+    // <NDR: pointer> PRPC_SID Sid;
     private RPC_SID sid;
 
     public RPC_UNICODE_STRING getName() {
@@ -60,22 +65,20 @@ public class LSAPR_POLICY_PRIMARY_DOM_INFO implements Unmarshallable {
     }
 
     @Override
-    public Alignment getAlignment() {
-        // RPC_UNICODE_STRING: 4
-        // PRPC_SID: 4
-        return Alignment.FOUR;
-    }
-
-    @Override
     public void unmarshalPreamble(PacketInput in) throws IOException {
+        // <NDR: struct> RPC_UNICODE_STRING Name;
         name = RPC_UNICODE_STRING.of(false);
         name.unmarshalPreamble(in);
     }
 
     @Override
     public void unmarshalEntity(PacketInput in) throws IOException {
+        // Structure Alignment: 4
+        in.align(Alignment.FOUR);
+        // <NDR: struct> RPC_UNICODE_STRING Name;
         name.unmarshalEntity(in);
-        // RPC_UNICODE_STRING.unmarshalEntity reads exactly 4 bytes, no need for alignment
+        // <NDR: pointer> PRPC_SID Sid;
+        // Alignment: 4 - Already aligned
         if (in.readReferentID() != 0) {
             sid = new RPC_SID();
         }
@@ -84,9 +87,8 @@ public class LSAPR_POLICY_PRIMARY_DOM_INFO implements Unmarshallable {
     @Override
     public void unmarshalDeferrals(PacketInput in) throws IOException {
         name.unmarshalDeferrals(in);
-        // RPC_UNICODE_STRING.unmarshalDeferrals writes a variable number of bytes, align before continuing
         if (sid != null) {
-            in.align(sid.getAlignment());
+            // <NDR: struct>
             in.readUnmarshallable(sid);
         }
     }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPR_ENUMERATION_BUFFER.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPR_ENUMERATION_BUFFER.java
@@ -42,6 +42,10 @@ import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
  *
  * @see <a href="https://msdn.microsoft.com/en-us/library/cc245561.aspx">
  *       https://msdn.microsoft.com/en-us/library/cc245561.aspx</a>
+ *
+ * Alignment: 4 (Max[4, 4])
+ *      unsigned long EntriesRead;: 4
+ *      [size_is(EntriesRead)] PSAMPR_RID_ENUMERATION;: 4 (Max[4, 4])
  */
 public abstract class SAMPR_ENUMERATION_BUFFER<T extends Unmarshallable> implements Unmarshallable {
 
@@ -72,24 +76,23 @@ public abstract class SAMPR_ENUMERATION_BUFFER<T extends Unmarshallable> impleme
     }
 
     @Override
-    public Alignment getAlignment() {
-        return Alignment.FOUR;
-    }
-
-    @Override
     public void unmarshalPreamble(PacketInput in) throws IOException {
+
     }
 
     @Override
     public void unmarshalEntity(PacketInput in) throws IOException {
-        // Entries of sam_array
+        // Structure Alignment
+        in.align(Alignment.FOUR);
+        // <NDR: unsigned long> unsigned long EntriesRead;
+        // Alignment: 4 - Already aligned
         entriesRead = in.readInt();
-        // Reference ID of domain_list
+        // <NDR: pointer> [size_is(EntriesRead)] PSAMPR_RID_ENUMERATION Buffer;
+        // Alignment: 4 - Already aligned
         if (in.readReferentID() != 0) {
             if (entriesRead > 0)
                 array = new ArrayList<>(entriesRead);
         }
-
     }
 
     @Override
@@ -97,6 +100,7 @@ public abstract class SAMPR_ENUMERATION_BUFFER<T extends Unmarshallable> impleme
         // Entries of domain_list
         if (array != null) {
             // MaximumCount
+            in.align(Alignment.FOUR);
             int count = in.readInt();
             for (int i = 0; i < count; i++) {
                 T t = initEntity();

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPR_RID_ENUMERATION.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPR_RID_ENUMERATION.java
@@ -27,13 +27,18 @@ import com.rapid7.client.dcerpc.objects.RPC_UNICODE_STRING;
 /**
  * This class represents the structure returned with {@link EnumeratedDomains}.
  *
- * <pre>
- * Relative ID (idx)  - index
- * RPC_UNICODE_STRING - Domain Name
- * </pre>
+ *  typedef struct _SAMPR_RID_ENUMERATION {
+ *      unsigned long RelativeId;
+ *      RPC_UNICODE_STRING Name;
+ *  } SAMPR_RID_ENUMERATION,
+ *  *PSAMPR_RID_ENUMERATION;
  *
  * @see <a href="https://msdn.microsoft.com/en-us/library/cc245560.aspx">
  *       https://msdn.microsoft.com/en-us/library/cc245560.aspx</a>
+ *
+ * Alignment: 4 (Max[4, 4])
+ *      unsigned long RelativeId: 4
+ *      RPC_UNICODE_STRING Name: 4
  */
 public class SAMPR_RID_ENUMERATION implements Unmarshallable {
 
@@ -57,17 +62,15 @@ public class SAMPR_RID_ENUMERATION implements Unmarshallable {
     }
 
     @Override
-    public Alignment getAlignment() {
-        return Alignment.FOUR;
-    }
-
-    @Override
     public void unmarshalPreamble(PacketInput in) throws IOException {
     }
 
     @Override
     public void unmarshalEntity(PacketInput in) throws IOException {
-        // relative ID.
+        // Structure Alignment
+        in.align(Alignment.FOUR);
+        // <NDR: unsigned long> unsigned long RelativeId;
+        // Alignment: 4 - Already aligned
         relativeId = in.readInt();
         name = RPC_UNICODE_STRING.of(false);
         name.unmarshalEntity(in);

--- a/src/main/java/com/rapid7/client/dcerpc/objects/ContextHandle.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/ContextHandle.java
@@ -30,14 +30,15 @@ import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
 /***
  * This class represents any NDR context handle. It is defined to be a struct of 16 bytes:
  *
- *   typedef struct ndr_context_handle
- *   {
+ *   typedef struct ndr_context_handle {
  *      ULONG      attributes;
  *      GUID       uuid;
  *   } ndr_context_handle;
  *
  * However, since the server will be computing these handles, DCERPC will treat these as:
  *   byte[20]
+ *
+ * Alignment: 1
  */
 public class ContextHandle implements Unmarshallable, Marshallable {
     private final byte[] handle;
@@ -81,19 +82,13 @@ public class ContextHandle implements Unmarshallable, Marshallable {
     }
 
     @Override
-    public Alignment getAlignment() {
-        // Size Alignment: N/A
-        // Element Alignment: 1
-        return Alignment.ONE;
-    }
-
-    @Override
     public void marshalPreamble(PacketOutput out) throws IOException {
         // Fixed array
     }
 
     @Override
     public void marshalEntity(PacketOutput out) throws IOException {
+        // Structure is aligned
         out.write(this.handle);
     }
 
@@ -109,6 +104,9 @@ public class ContextHandle implements Unmarshallable, Marshallable {
 
     @Override
     public void unmarshalEntity(PacketInput in) throws IOException {
+        // Structure Alignment: 1
+        // <NDR: fixed array> byte[]
+        // Alignment: 1
         in.readFully(this.handle);
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/objects/RPC_UNICODE_STRING.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/RPC_UNICODE_STRING.java
@@ -32,8 +32,7 @@ import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
  *      typedef struct _RPC_UNICODE_STRING {
  *          unsigned short Length;
  *          unsigned short MaximumLength;
- *          [size_is(MaximumLength/2), length_is(Length/2)]
- *          WCHAR* Buffer;
+ *          [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer;
  *      } RPC_UNICODE_STRING,
  *      *PRPC_UNICODE_STRING;
  *
@@ -54,6 +53,11 @@ import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
  *      RPC_UNICODE_STRING rpcUnicodeString = RPC_UNICODE_STRING.of(true);
  *      packetIn.readUnmarshallable(rpcUnicodeString);
  *      String myValue = rpcUnicodeString.getValue();
+ *
+ * Alignment: 4
+ *      unsigned short Length;: 2
+ *      unsigned short MaximumLength;: 2
+ *      [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer;: 4 (Max[4, 1])
  */
 public abstract class RPC_UNICODE_STRING implements Unmarshallable, Marshallable {
 
@@ -111,32 +115,36 @@ public abstract class RPC_UNICODE_STRING implements Unmarshallable, Marshallable
     }
 
     @Override
-    public Alignment getAlignment() {
-        /*
-         * unsigned short Length: 2
-         * unsigned short MaximumLength: 2
-         * [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer: 4
-         */
-        return Alignment.FOUR;
-    }
-
-    @Override
     public void marshalPreamble(PacketOutput out) throws IOException {
         // No preamble. Conformant array of `WCHAR*` is a reference, and so preamble is not required.
     }
 
     @Override
     public void marshalEntity(PacketOutput out) throws IOException {
+        // Structure Alignment
+        out.align(Alignment.FOUR);
         if (value == null) {
+            // <NDR: unsigned short> unsigned short Length;
+            // Alignment 2 - Already aligned
             out.writeShort((short) 0);
+            // <NDR: unsigned short> unsigned short MaximumLength;
+            // Alignment 2 - Already aligned
             out.writeShort((short) 0);
+            // <NDR: pointer> [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer;
+            // Alignment 4 - Already aligned
             out.writeNull();
         } else {
             // UTF-16 encoded string is 2 bytes per count point
             // Null terminator must also be considered
             final int byteLength = 2 * value.length() + (isNullTerminated() ? 2 : 0);
+            // <NDR: unsigned short> unsigned short Length;
+            // Alignment 2 - Already aligned
             out.writeShort((short) byteLength);
+            // <NDR: unsigned short> unsigned short MaximumLength;
+            // Alignment 2 - Already aligned
             out.writeShort((short) byteLength);
+            // <NDR: pointer> [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer;
+            // Alignment 4 - Already aligned
             out.writeReferentID();
         }
     }
@@ -145,23 +153,20 @@ public abstract class RPC_UNICODE_STRING implements Unmarshallable, Marshallable
     public void marshalDeferrals(PacketOutput out) throws IOException {
         if (value != null) {
             final int codepoints = value.length() + (isNullTerminated() ? 1 : 0);
-            //Preamble
             // MaximumCount for conformant array
+            out.align(Alignment.FOUR);
             out.writeInt(codepoints);
-
-            //Entity
             // Offset for varying array
+            // Alignment 4 - Already aligned
             out.writeInt(0);
             // ActualCount for varying array
+            // Alignment 4 - Already aligned
             out.writeInt(codepoints);
-
-            //Deferrals
             // Entities for conformant+varying array
+            // Alignment 1 - Already aligned
             out.writeChars(value);
             if (isNullTerminated())
                 out.writeShort((short) 0);
-            // Align the conformant+varying array
-            out.align(Alignment.FOUR);
         }
     }
 
@@ -172,8 +177,16 @@ public abstract class RPC_UNICODE_STRING implements Unmarshallable, Marshallable
 
     @Override
     public void unmarshalEntity(PacketInput in) throws IOException {
+        // Structure Alignment: 4
+        in.align(Alignment.FOUR);
+        // <NDR: unsigned short> unsigned short Length;
+        // Alignment: 2 - Already aligned
         in.readShort();
+        // <NDR: unsigned short> unsigned short MaximumLength;
+        // Alignment: 2 - Already aligned
         in.readShort();
+        // <NDR: pointer> [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer;
+        // Alignment: 4 - Already aligned
         if (in.readReferentID() != 0)
             // This is 0 cost - Compile time constants are internal objects
             value = "";
@@ -183,13 +196,16 @@ public abstract class RPC_UNICODE_STRING implements Unmarshallable, Marshallable
     public void unmarshalDeferrals(PacketInput in) throws IOException {
         if (value != null) {
             //Preamble
-            // MaximumCount for conformant array - This is *not* the size of the array, so is not useful to us
+            // <NDR: unsigned long> MaximumCount for conformant array - This is *not* the size of the array, so is not useful to us
+            in.align(Alignment.FOUR);
             in.readInt();
 
             //Entity
-            // Offset for varying array
+            // <NDR: unsigned long> Offset for varying array
+            // Alignment: 4 - Already aligned
             final int offset = in.readInt();
-            // ActualCount for varying array
+            // <NDR: unsigned long> ActualCount for varying array
+            // Alignment: 4 - Already aligned
             final int actualCount = in.readInt();
             // If we expect a null terminator, then skip it when reading the string
             final int stringCount = (isNullTerminated() ? (actualCount - 1) : actualCount);
@@ -199,18 +215,22 @@ public abstract class RPC_UNICODE_STRING implements Unmarshallable, Marshallable
             final StringBuilder result = new StringBuilder(stringCount);
             // Read prefix (if any)
             for (int i = 0; i < offset; i++) {
+                // <NDR: unsigned short>
+                // Alignment: 2 - Already aligned
                 in.readShort();
             }
             // Read subset
             for (int i = 0; i < stringCount; i++) {
+                // <NDR: unsigned short>
+                // Alignment: 2 - Already aligned
                 result.append((char) in.readShort());
             }
             // Read suffix (if any)
             for (int i = stringCount; i < actualCount; i++) {
+                // <NDR: unsigned short>
+                // Alignment: 2 - Already aligned
                 in.readShort();
             }
-            // Align the conformant+varying array
-            in.align(Alignment.FOUR);
             this.value = result.toString();
         }
     }

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/messages/Test_LsarQueryInformationPolicyResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/messages/Test_LsarQueryInformationPolicyResponse.java
@@ -18,7 +18,6 @@
  *
  *
  */
-
 package com.rapid7.client.dcerpc.mslsad.messages;
 
 import java.io.ByteArrayInputStream;
@@ -33,7 +32,6 @@ import com.rapid7.client.dcerpc.mslsad.objects.POLICY_INFORMATION_CLASS;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
@@ -51,23 +49,15 @@ public class Test_LsarQueryInformationPolicyResponse {
     public Object[][] data_unmarshal() {
         return new Object[][] {
                 // Reference: 1, POLICY_CLASS_INFORMATION: 3
-                {"01000000 0300", Alignment.ONE},
-                // Reference: 1, POLICY_CLASS_INFORMATION: 3
-                {"01000000 0300", Alignment.TWO},
-                // Test alignments:
-                // Reference: 1, POLICY_CLASS_INFORMATION: 3, alignment: 2b
-                {"01000000 0300 0000", Alignment.FOUR},
-                // Reference: 1, POLICY_CLASS_INFORMATION: 3, alignment: 2b
-                {"01000000 0300 0000", Alignment.EIGHT}
+                {"01000000 0300"},
         };
     }
 
     @Test(dataProvider = "data_unmarshal")
-    public void test_unmarshal(String hex, Alignment alignment) throws IOException {
+    public void test_unmarshal(String hex) throws IOException {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = new PacketInput(bin);
         Unmarshallable unmarshallable = mock(Unmarshallable.class);
-        when(unmarshallable.getAlignment()).thenReturn(alignment);
         doNothing().when(unmarshallable).unmarshalPreamble(in);
         doNothing().when(unmarshallable).unmarshalEntity(in);
         doNothing().when(unmarshallable).unmarshalDeferrals(in);

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPR_POLICY_ACCOUNT_DOM_INFO.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPR_POLICY_ACCOUNT_DOM_INFO.java
@@ -18,7 +18,6 @@
  *
  *
  */
-
 package com.rapid7.client.dcerpc.mslsad.objects;
 
 import java.io.ByteArrayInputStream;
@@ -27,7 +26,6 @@ import org.bouncycastle.util.encoders.Hex;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import com.rapid7.client.dcerpc.io.PacketInput;
-import com.rapid7.client.dcerpc.io.ndr.Alignment;
 import com.rapid7.client.dcerpc.objects.RPC_SID;
 import com.rapid7.client.dcerpc.objects.RPC_UNICODE_STRING;
 
@@ -40,7 +38,6 @@ public class Test_LSAPR_POLICY_ACCOUNT_DOM_INFO {
     @Test
     public void test_getters_default() {
         LSAPR_POLICY_ACCOUNT_DOM_INFO obj = new LSAPR_POLICY_ACCOUNT_DOM_INFO();
-        assertEquals(obj.getAlignment(), Alignment.FOUR);
         assertNull(obj.getDomainName());
         assertNull(obj.getDomainSid());
     }
@@ -70,18 +67,27 @@ public class Test_LSAPR_POLICY_ACCOUNT_DOM_INFO {
     public Object[][] data_unmarshalEntity() {
         return new Object[][] {
                 // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
-                {"0200 0300 01000000 00000000", RPC_UNICODE_STRING.of(false, ""), null},
+                {"0200 0300 01000000 00000000", 0, RPC_UNICODE_STRING.of(false, ""), null},
+                // Alignment: 1, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
+                {"ffffffff 0200 0300 01000000 00000000", 3, RPC_UNICODE_STRING.of(false, ""), null},
+                // Alignment: 2, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
+                {"ffffffff 0200 0300 01000000 00000000", 2, RPC_UNICODE_STRING.of(false, ""), null},
+                // Alignment: 3, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
+                {"ffffffff 0200 0300 01000000 00000000", 1, RPC_UNICODE_STRING.of(false, ""), null},
                 // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
-                {"0200 0300 01000000 02000000", RPC_UNICODE_STRING.of(false, ""), new RPC_SID()},
+                {"0200 0300 01000000 02000000", 0, RPC_UNICODE_STRING.of(false, ""), new RPC_SID()},
         };
     }
 
     @Test(dataProvider = "data_unmarshalEntity")
-    public void test_unmarshalEntity(String hex, RPC_UNICODE_STRING expectedName, RPC_SID expectedSid) throws Exception {
+    public void test_unmarshalEntity(String hex, int mark, RPC_UNICODE_STRING expectedName, RPC_SID expectedSid) throws Exception {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        in.readFully(new byte[mark]);
+
         LSAPR_POLICY_ACCOUNT_DOM_INFO obj = new LSAPR_POLICY_ACCOUNT_DOM_INFO();
         obj.setDomainName(RPC_UNICODE_STRING.of(false));
-        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
-        obj.unmarshalEntity(new PacketInput(bin));
+        obj.unmarshalEntity(in);
         assertEquals(bin.available(), 0);
         assertEquals(obj.getDomainName(), expectedName);
         assertEquals(obj.getDomainSid(), expectedSid);

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPR_POLICY_PRIMARY_DOM_INFO.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPR_POLICY_PRIMARY_DOM_INFO.java
@@ -18,7 +18,6 @@
  *
  *
  */
-
 package com.rapid7.client.dcerpc.mslsad.objects;
 
 import java.io.ByteArrayInputStream;
@@ -28,13 +27,11 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.rapid7.client.dcerpc.io.PacketInput;
-import com.rapid7.client.dcerpc.io.ndr.Alignment;
 import com.rapid7.client.dcerpc.objects.RPC_SID;
 import com.rapid7.client.dcerpc.objects.RPC_UNICODE_STRING;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 
@@ -42,7 +39,6 @@ public class Test_LSAPR_POLICY_PRIMARY_DOM_INFO {
     @Test
     public void test_getters_default() {
         LSAPR_POLICY_PRIMARY_DOM_INFO obj = new LSAPR_POLICY_PRIMARY_DOM_INFO();
-        assertEquals(obj.getAlignment(), Alignment.FOUR);
         assertNull(obj.getName());
         assertNull(obj.getSid());
     }
@@ -72,18 +68,27 @@ public class Test_LSAPR_POLICY_PRIMARY_DOM_INFO {
     public Object[][] data_unmarshalEntity() {
         return new Object[][] {
                 // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
-                {"0200 0300 01000000 00000000", RPC_UNICODE_STRING.of(false, ""), null},
+                {"0200 0300 01000000 00000000", 0, RPC_UNICODE_STRING.of(false, ""), null},
                 // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
-                {"0200 0300 01000000 02000000", RPC_UNICODE_STRING.of(false, ""), new RPC_SID()},
+                {"0200 0300 01000000 02000000", 0, RPC_UNICODE_STRING.of(false, ""), new RPC_SID()},
+                // Alignment: 3, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
+                {"ffffffff 0200 0300 01000000 02000000", 1, RPC_UNICODE_STRING.of(false, ""), new RPC_SID()},
+                // Alignment: 2, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
+                {"ffffffff 0200 0300 01000000 02000000", 2, RPC_UNICODE_STRING.of(false, ""), new RPC_SID()},
+                // Alignment: 1, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
+                {"ffffffff 0200 0300 01000000 02000000", 3, RPC_UNICODE_STRING.of(false, ""), new RPC_SID()},
         };
     }
 
     @Test(dataProvider = "data_unmarshalEntity")
-    public void test_unmarshalEntity(String hex, RPC_UNICODE_STRING expectedName, RPC_SID expectedSid) throws Exception {
+    public void test_unmarshalEntity(String hex, int mark, RPC_UNICODE_STRING expectedName, RPC_SID expectedSid) throws Exception {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        in.readFully(new byte[mark]);
+
         LSAPR_POLICY_PRIMARY_DOM_INFO obj = new LSAPR_POLICY_PRIMARY_DOM_INFO();
         obj.setName(RPC_UNICODE_STRING.of(false));
-        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
-        obj.unmarshalEntity(new PacketInput(bin));
+        obj.unmarshalEntity(in);
         assertEquals(bin.available(), 0);
         assertEquals(obj.getName(), expectedName);
         assertEquals(obj.getSid(), expectedSid);


### PR DESCRIPTION
Previously, all `DataType`'s needed to report their alignment sizes via `Alignment getAlignment()`. Using this, it was the caller's responsibility to align the stream before writing the object.

However, this only works for `marshalEntity`. Separate alignments for both the preamble and deferrals must be considered.

To accomodate this, instead of introducing two more getters, the `DataType`'s are now responsible for their own alignment. This comes at a very small CPU cost when the stream is already known to be aligned, and alignment was not required, but greatly simplifies the reuse of structs within the framework.

- All existing `DataType` implementations now align themselves to the appropriate alignment in all three stages: preamble, entity, and deferrals
- Unit tests have been added to ensure that alignment takes place where expected
- Updating README.md with new alignment strategy. Adding additional examples