### PR TITLE
Forcing UTF-8 source encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
       <thirdparty.testng.version>6.11</thirdparty.testng.version>
       <maven.compiler.target>1.7</maven.compiler.target>
       <maven.compiler.source>1.7</maven.compiler.source>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    </properties>
 
    <dependencies>


### PR DESCRIPTION
Windows uses cp1252 by default, which will not be compatible with any source files containing utf-8 characters and expecting those bytes to be identical.