### PR TITLE
Refactoring RPCUnicodeString

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRPolicyAccountDomInfo.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRPolicyAccountDomInfo.java
@@ -115,6 +115,6 @@ public class LSAPRPolicyAccountDomInfo implements Unmarshallable {
 
     @Override
     public String toString() {
-        return String.format("LSAPR_POLICY_ACCOUNT_DOM_INFO{DomainName:%s, DomainSid:%s}", this.domainName, this.domainSid);
+        return String.format("LSAPR_POLICY_ACCOUNT_DOM_INFO{DomainName:%s, DomainSid:%s}", getDomainName(), getDomainSid());
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRPolicyAccountDomInfo.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRPolicyAccountDomInfo.java
@@ -48,15 +48,15 @@ import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 public class LSAPRPolicyAccountDomInfo implements Unmarshallable {
 
     // <NDR: struct> RPC_UNICODE_STRING DomainName;
-    private RPCUnicodeString domainName;
+    private RPCUnicodeString.NonNullTerminated domainName;
     // <NDR: pointer> PRPC_SID DomainSid;
     private RPCSID domainSid;
 
-    public RPCUnicodeString getDomainName() {
+    public RPCUnicodeString.NonNullTerminated getDomainName() {
         return domainName;
     }
 
-    public void setDomainName(RPCUnicodeString domainName) {
+    public void setDomainName(RPCUnicodeString.NonNullTerminated domainName) {
         this.domainName = domainName;
     }
 
@@ -70,7 +70,7 @@ public class LSAPRPolicyAccountDomInfo implements Unmarshallable {
 
     @Override
     public void unmarshalPreamble(PacketInput in) throws IOException {
-        domainName = RPCUnicodeString.of(false);
+        domainName = new RPCUnicodeString.NonNullTerminated();
         domainName.unmarshalPreamble(in);
     }
 
@@ -115,6 +115,6 @@ public class LSAPRPolicyAccountDomInfo implements Unmarshallable {
 
     @Override
     public String toString() {
-        return String.format("LSAPR_POLICY_ACCOUNT_DOM_INFO{DomainName:%s, DomainSid:%s}", getDomainName(), getDomainSid());
+        return String.format("LSAPR_POLICY_ACCOUNT_DOM_INFO{DomainName:%s, DomainSid:%s}", this.domainName, this.domainSid);
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRPolicyPrimaryDomInfo.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRPolicyPrimaryDomInfo.java
@@ -49,15 +49,15 @@ import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 public class LSAPRPolicyPrimaryDomInfo implements Unmarshallable {
 
     // <NDR: struct> RPC_UNICODE_STRING Name;
-    private RPCUnicodeString name;
+    private RPCUnicodeString.NonNullTerminated name;
     // <NDR: pointer> PRPC_SID Sid;
     private RPCSID sid;
 
-    public RPCUnicodeString getName() {
+    public RPCUnicodeString.NonNullTerminated getName() {
         return name;
     }
 
-    public void setName(RPCUnicodeString name) {
+    public void setName(RPCUnicodeString.NonNullTerminated name) {
         this.name = name;
     }
 
@@ -72,7 +72,7 @@ public class LSAPRPolicyPrimaryDomInfo implements Unmarshallable {
     @Override
     public void unmarshalPreamble(PacketInput in) throws IOException {
         // <NDR: struct> RPC_UNICODE_STRING Name;
-        name = RPCUnicodeString.of(false);
+        name = new RPCUnicodeString.NonNullTerminated();
         name.unmarshalPreamble(in);
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRRIDEnumeration.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRRIDEnumeration.java
@@ -44,13 +44,13 @@ import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 public class SAMPRRIDEnumeration implements Unmarshallable {
 
     private int relativeId;
-    private RPCUnicodeString name;
+    private RPCUnicodeString.NonNullTerminated name;
 
-    public String getName() {
-        return name.getValue();
+    public RPCUnicodeString.NonNullTerminated getName() {
+        return name;
     }
 
-    public void setName(final RPCUnicodeString name) {
+    public void setName(final RPCUnicodeString.NonNullTerminated name) {
         this.name = name;
     }
 
@@ -73,7 +73,7 @@ public class SAMPRRIDEnumeration implements Unmarshallable {
         // <NDR: unsigned long> unsigned long RelativeId;
         // Alignment: 4 - Already aligned
         relativeId = in.readInt();
-        name = RPCUnicodeString.of(false);
+        name = new RPCUnicodeString.NonNullTerminated();
         name.unmarshalEntity(in);
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/objects/RPCUnicodeString.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/RPCUnicodeString.java
@@ -69,30 +69,19 @@ import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
 public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
 
     /**
-     * Convenience method for construction of RPC_UNICODE_STRING.
-     * @param nullTerminated Whether or not the RPC_UNICODE_STRING is null terminated.
-     * @return A new RPC_UNICODE_STRING with an initial value of null.
-     */
-    public static RPCUnicodeString of(boolean nullTerminated) {
-        return (nullTerminated ? new NullTerminated() : new NotNullTerminated());
-    }
-
-    /**
-     * Convenience method for construction of RPC_UNICODE_STRING.
-     * @param nullTerminated Whether or not the RPC_UNICODE_STRING is null terminated.
-     * @param value The initial value of the RPC_UNICODE_STRING.
-     * @return A new RPC_UNICODE_STRING with the provided initial value.
-     */
-    public static RPCUnicodeString of(boolean nullTerminated, String value) {
-        RPCUnicodeString obj = of(nullTerminated);
-        obj.setValue(value);
-        return obj;
-    }
-
-    /**
      * An RPC_UNICODE_STRING which is expected to be null terminated during marshalling/unmarshalling.
      */
-    static class NullTerminated extends RPCUnicodeString {
+    public static class NullTerminated extends RPCUnicodeString {
+        public static NullTerminated of(String value) {
+            NullTerminated str = of();
+            str.setValue(value);
+            return str;
+        }
+
+        public static NullTerminated of() {
+            return new NullTerminated();
+        }
+
         @Override
         boolean isNullTerminated() {
             return true;
@@ -102,7 +91,13 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
     /**
      * An RPC_UNICODE_STRING which is not expected to be null terminated during marshalling/unmarshalling.
      */
-    static class NotNullTerminated extends RPCUnicodeString {
+    public static class NonNullTerminated extends RPCUnicodeString {
+        public static NonNullTerminated of(String value) {
+            NonNullTerminated str = new NonNullTerminated();
+            str.setValue(value);
+            return str;
+        }
+
         @Override
         boolean isNullTerminated() {
             return false;

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPRPolicyAccountDomInfo.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPRPolicyAccountDomInfo.java
@@ -45,7 +45,7 @@ public class Test_LSAPRPolicyAccountDomInfo {
     @Test
     public void test_setters() {
         LSAPRPolicyAccountDomInfo obj = new LSAPRPolicyAccountDomInfo();
-        RPCUnicodeString name = RPCUnicodeString.of(false, "test 123");
+        RPCUnicodeString.NonNullTerminated name = RPCUnicodeString.NonNullTerminated.of("test 123");
         obj.setDomainName(name);
         RPCSID sid = new RPCSID();
         obj.setDomainSid(sid);
@@ -59,7 +59,7 @@ public class Test_LSAPRPolicyAccountDomInfo {
         assertNull(obj.getDomainName());
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode("010203"));
         obj.unmarshalPreamble(new PacketInput(bin));
-        assertEquals(obj.getDomainName(), RPCUnicodeString.of(false));
+        assertEquals(obj.getDomainName(), new RPCUnicodeString.NonNullTerminated());
         assertEquals(bin.available(), 3);
     }
 
@@ -67,41 +67,41 @@ public class Test_LSAPRPolicyAccountDomInfo {
     public Object[][] data_unmarshalEntity() {
         return new Object[][] {
                 // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
-                {"0200 0300 01000000 00000000", 0, RPCUnicodeString.of(false, ""), null},
+                {"0200 0300 01000000 00000000", 0, null},
                 // Alignment: 1, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
-                {"ffffffff 0200 0300 01000000 00000000", 3, RPCUnicodeString.of(false, ""), null},
+                {"ffffffff 0200 0300 01000000 00000000", 3, null},
                 // Alignment: 2, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
-                {"ffffffff 0200 0300 01000000 00000000", 2, RPCUnicodeString.of(false, ""), null},
+                {"ffffffff 0200 0300 01000000 00000000", 2, null},
                 // Alignment: 3, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
-                {"ffffffff 0200 0300 01000000 00000000", 1, RPCUnicodeString.of(false, ""), null},
+                {"ffffffff 0200 0300 01000000 00000000", 1, null},
                 // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
-                {"0200 0300 01000000 02000000", 0, RPCUnicodeString.of(false, ""), new RPCSID()},
+                {"0200 0300 01000000 02000000", 0, new RPCSID()},
         };
     }
 
     @Test(dataProvider = "data_unmarshalEntity")
-    public void test_unmarshalEntity(String hex, int mark, RPCUnicodeString expectedName, RPCSID expectedSid) throws Exception {
+    public void test_unmarshalEntity(String hex, int mark, RPCSID expectedSid) throws Exception {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = new PacketInput(bin);
         in.readFully(new byte[mark]);
 
         LSAPRPolicyAccountDomInfo obj = new LSAPRPolicyAccountDomInfo();
-        obj.setDomainName(RPCUnicodeString.of(false));
+        obj.setDomainName(new RPCUnicodeString.NonNullTerminated());
         obj.unmarshalEntity(in);
         assertEquals(bin.available(), 0);
-        assertEquals(obj.getDomainName(), expectedName);
+        assertEquals(obj.getDomainName(), RPCUnicodeString.NonNullTerminated.of(""));
         assertEquals(obj.getDomainSid(), expectedSid);
     }
 
     @DataProvider
     public Object[][] data_unmarshalDeferrals() {
-        RPCUnicodeString name1 = RPCUnicodeString.of(false, "test 123");
+        RPCUnicodeString.NonNullTerminated name1 = RPCUnicodeString.NonNullTerminated.of("test 123");
         RPCSID sid1 = new RPCSID();
         sid1.setRevision((char) 1);
         sid1.setSubAuthorityCount((char) 4);
         sid1.setIdentifierAuthority(new byte[]{0,0,0,0,0,5});
         sid1.setSubAuthority(new long[]{1,2,3,4});
-        RPCUnicodeString name2 = RPCUnicodeString.of(false, "test 1234");
+        RPCUnicodeString.NonNullTerminated name2 = RPCUnicodeString.NonNullTerminated.of("test 1234");
         return new Object[][] {
                 // Name MaximumCount: 9, Offset: 0, ActualCount: 8, Value: "test 123"
                 // SID MaximumCount: 4, Revision: 1, SubAuthorityCount: 4, IdentifierAuthority:{0,0,0,0,0,5}, SubAuthority:{1,2,3,4}
@@ -122,9 +122,9 @@ public class Test_LSAPRPolicyAccountDomInfo {
     }
 
     @Test(dataProvider = "data_unmarshalDeferrals")
-    public void test_unmarshalDeferrals(String hex, RPCSID sid, RPCUnicodeString expectedName, RPCSID expectedSid) throws Exception {
+    public void test_unmarshalDeferrals(String hex, RPCSID sid, RPCUnicodeString.NonNullTerminated expectedName, RPCSID expectedSid) throws Exception {
         LSAPRPolicyAccountDomInfo obj = new LSAPRPolicyAccountDomInfo();
-        obj.setDomainName(RPCUnicodeString.of(false, ""));
+        obj.setDomainName(RPCUnicodeString.NonNullTerminated.of(""));
         obj.setDomainSid(sid);
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         obj.unmarshalDeferrals(new PacketInput(bin));
@@ -138,9 +138,9 @@ public class Test_LSAPRPolicyAccountDomInfo {
         LSAPRPolicyAccountDomInfo obj1 = new LSAPRPolicyAccountDomInfo();
         LSAPRPolicyAccountDomInfo obj2 = new LSAPRPolicyAccountDomInfo();
         assertEquals(obj1.hashCode(), obj2.hashCode());
-        obj1.setDomainName(RPCUnicodeString.of(false));
+        obj1.setDomainName(new RPCUnicodeString.NonNullTerminated());
         assertNotEquals(obj1.hashCode(), obj2.hashCode());
-        obj2.setDomainName(RPCUnicodeString.of(false));
+        obj2.setDomainName(new RPCUnicodeString.NonNullTerminated());
         assertEquals(obj1.hashCode(), obj2.hashCode());
         obj1.setDomainSid(new RPCSID());
         assertNotEquals(obj1.hashCode(), obj2.hashCode());
@@ -155,9 +155,9 @@ public class Test_LSAPRPolicyAccountDomInfo {
         assertNotEquals(obj1, null);
         LSAPRPolicyAccountDomInfo obj2 = new LSAPRPolicyAccountDomInfo();
         assertEquals(obj1, obj2);
-        obj1.setDomainName(RPCUnicodeString.of(false));
+        obj1.setDomainName(new RPCUnicodeString.NonNullTerminated());
         assertNotEquals(obj1, obj2);
-        obj2.setDomainName(RPCUnicodeString.of(false));
+        obj2.setDomainName(new RPCUnicodeString.NonNullTerminated());
         assertEquals(obj1, obj2);
         obj1.setDomainSid(new RPCSID());
         assertNotEquals(obj1, obj2);
@@ -174,7 +174,7 @@ public class Test_LSAPRPolicyAccountDomInfo {
     @Test
     public void test_toString() {
         LSAPRPolicyAccountDomInfo obj = new LSAPRPolicyAccountDomInfo();
-        obj.setDomainName(RPCUnicodeString.of(false, "test 123"));
+        obj.setDomainName(RPCUnicodeString.NonNullTerminated.of("test 123"));
         RPCSID sid = new RPCSID();
         sid.setRevision((char) 1);
         sid.setSubAuthorityCount((char) 4);

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPRPolicyPrimaryDomInfo.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPRPolicyPrimaryDomInfo.java
@@ -46,7 +46,7 @@ public class Test_LSAPRPolicyPrimaryDomInfo {
     @Test
     public void test_setters() {
         LSAPRPolicyPrimaryDomInfo obj = new LSAPRPolicyPrimaryDomInfo();
-        RPCUnicodeString name = RPCUnicodeString.of(false, "test 123");
+        RPCUnicodeString.NonNullTerminated name = RPCUnicodeString.NonNullTerminated.of("test 123");
         obj.setName(name);
         RPCSID sid = new RPCSID();
         obj.setSid(sid);
@@ -60,7 +60,7 @@ public class Test_LSAPRPolicyPrimaryDomInfo {
         assertNull(obj.getName());
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode("010203"));
         obj.unmarshalPreamble(new PacketInput(bin));
-        assertEquals(obj.getName(), RPCUnicodeString.of(false));
+        assertEquals(obj.getName(), new RPCUnicodeString.NonNullTerminated());
         assertEquals(bin.available(), 3);
     }
 
@@ -68,41 +68,41 @@ public class Test_LSAPRPolicyPrimaryDomInfo {
     public Object[][] data_unmarshalEntity() {
         return new Object[][] {
                 // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 0
-                {"0200 0300 01000000 00000000", 0, RPCUnicodeString.of(false, ""), null},
+                {"0200 0300 01000000 00000000", 0, null},
                 // Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
-                {"0200 0300 01000000 02000000", 0, RPCUnicodeString.of(false, ""), new RPCSID()},
+                {"0200 0300 01000000 02000000", 0, new RPCSID()},
                 // Alignment: 3, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
-                {"ffffffff 0200 0300 01000000 02000000", 1, RPCUnicodeString.of(false, ""), new RPCSID()},
+                {"ffffffff 0200 0300 01000000 02000000", 1, new RPCSID()},
                 // Alignment: 2, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
-                {"ffffffff 0200 0300 01000000 02000000", 2, RPCUnicodeString.of(false, ""), new RPCSID()},
+                {"ffffffff 0200 0300 01000000 02000000", 2, new RPCSID()},
                 // Alignment: 1, Name Length: 2, Name MaximumLength: 3, Name Reference: 1, SID Reference: 2
-                {"ffffffff 0200 0300 01000000 02000000", 3, RPCUnicodeString.of(false, ""), new RPCSID()},
+                {"ffffffff 0200 0300 01000000 02000000", 3, new RPCSID()},
         };
     }
 
     @Test(dataProvider = "data_unmarshalEntity")
-    public void test_unmarshalEntity(String hex, int mark, RPCUnicodeString expectedName, RPCSID expectedSid) throws Exception {
+    public void test_unmarshalEntity(String hex, int mark, RPCSID expectedSid) throws Exception {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = new PacketInput(bin);
         in.readFully(new byte[mark]);
 
         LSAPRPolicyPrimaryDomInfo obj = new LSAPRPolicyPrimaryDomInfo();
-        obj.setName(RPCUnicodeString.of(false));
+        obj.setName(new RPCUnicodeString.NonNullTerminated());
         obj.unmarshalEntity(in);
         assertEquals(bin.available(), 0);
-        assertEquals(obj.getName(), expectedName);
+        assertEquals(obj.getName(), RPCUnicodeString.NonNullTerminated.of(""));
         assertEquals(obj.getSid(), expectedSid);
     }
 
     @DataProvider
     public Object[][] data_unmarshalDeferrals() {
-        RPCUnicodeString name1 = RPCUnicodeString.of(false, "test 123");
+        RPCUnicodeString name1 = RPCUnicodeString.NonNullTerminated.of("test 123");
         RPCSID sid1 = new RPCSID();
         sid1.setRevision((char) 1);
         sid1.setSubAuthorityCount((char) 4);
         sid1.setIdentifierAuthority(new byte[]{0,0,0,0,0,5});
         sid1.setSubAuthority(new long[]{1,2,3,4});
-        RPCUnicodeString name2 = RPCUnicodeString.of(false, "test 1234");
+        RPCUnicodeString name2 = RPCUnicodeString.NonNullTerminated.of("test 1234");
         return new Object[][] {
                 // Name MaximumCount: 9, Offset: 0, ActualCount: 8, Value: "test 123"
                 // SID MaximumCount: 4, Revision: 1, SubAuthorityCount: 4, IdentifierAuthority:{0,0,0,0,0,5}, SubAuthority:{1,2,3,4}
@@ -125,7 +125,7 @@ public class Test_LSAPRPolicyPrimaryDomInfo {
     @Test(dataProvider = "data_unmarshalDeferrals")
     public void test_unmarshalDeferrals(String hex, RPCSID sid, RPCUnicodeString expectedName, RPCSID expectedSid) throws Exception {
         LSAPRPolicyPrimaryDomInfo obj = new LSAPRPolicyPrimaryDomInfo();
-        obj.setName(RPCUnicodeString.of(false, ""));
+        obj.setName(RPCUnicodeString.NonNullTerminated.of(""));
         obj.setSid(sid);
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         obj.unmarshalDeferrals(new PacketInput(bin));
@@ -139,9 +139,9 @@ public class Test_LSAPRPolicyPrimaryDomInfo {
         LSAPRPolicyPrimaryDomInfo obj1 = new LSAPRPolicyPrimaryDomInfo();
         LSAPRPolicyPrimaryDomInfo obj2 = new LSAPRPolicyPrimaryDomInfo();
         assertEquals(obj1.hashCode(), obj2.hashCode());
-        obj1.setName(RPCUnicodeString.of(false));
+        obj1.setName(new RPCUnicodeString.NonNullTerminated());
         assertNotEquals(obj1.hashCode(), obj2.hashCode());
-        obj2.setName(RPCUnicodeString.of(false));
+        obj2.setName(new RPCUnicodeString.NonNullTerminated());
         assertEquals(obj1.hashCode(), obj2.hashCode());
         obj1.setSid(new RPCSID());
         assertNotEquals(obj1.hashCode(), obj2.hashCode());
@@ -156,9 +156,9 @@ public class Test_LSAPRPolicyPrimaryDomInfo {
         assertNotEquals(obj1, null);
         LSAPRPolicyPrimaryDomInfo obj2 = new LSAPRPolicyPrimaryDomInfo();
         assertEquals(obj1, obj2);
-        obj1.setName(RPCUnicodeString.of(false));
+        obj1.setName(new RPCUnicodeString.NonNullTerminated());
         assertNotEquals(obj1, obj2);
-        obj2.setName(RPCUnicodeString.of(false));
+        obj2.setName(new RPCUnicodeString.NonNullTerminated());
         assertEquals(obj1, obj2);
         obj1.setSid(new RPCSID());
         assertNotEquals(obj1, obj2);
@@ -175,7 +175,7 @@ public class Test_LSAPRPolicyPrimaryDomInfo {
     @Test
     public void test_toString() {
         LSAPRPolicyPrimaryDomInfo obj = new LSAPRPolicyPrimaryDomInfo();
-        obj.setName(RPCUnicodeString.of(false, "test 123"));
+        obj.setName(RPCUnicodeString.NonNullTerminated.of("test 123"));
         RPCSID sid = new RPCSID();
         sid.setRevision((char) 1);
         sid.setSubAuthorityCount((char) 4);

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_EnumeratedDomains.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_EnumeratedDomains.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 
 public class Test_EnumeratedDomains {
     @Test
@@ -35,7 +36,7 @@ public class Test_EnumeratedDomains {
         PacketInput in = new PacketInput(inputStream);
         in.readUnmarshallable(domains);
         assertEquals(2, domains.getEntriesRead());
-        assertEquals("windows100", domains.getEntries().get(0).getName());
-        assertEquals("Builtin", domains.getEntries().get(1).getName());
+        assertEquals(RPCUnicodeString.NonNullTerminated.of("windows100"), domains.getEntries().get(0).getName());
+        assertEquals(RPCUnicodeString.NonNullTerminated.of("Builtin"), domains.getEntries().get(1).getName());
     }
 }


### PR DESCRIPTION
- RPCUnicodeString subclasses are now public
- Relevant structs now explicitly require either a null terminated or non null terminated RPCUnicodeString
- RPCUnicodeString static convenience methods are now within the respective subclasses