### PR TITLE
Adds additional unsigned primitive support and test coverage

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/io/PacketInput.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/PacketInput.java
@@ -44,6 +44,7 @@ public class PacketInput extends PrimitiveInput {
     }
 
     public int readReferentID() throws IOException {
+        // Currently only supports NDR20
         return readInt();
     }
 
@@ -122,10 +123,6 @@ public class PacketInput extends PrimitiveInput {
         }
 
         return result != null ? result.toString() : null;
-    }
-
-    public String readRPCUnicodeString(final boolean nullTerminated) throws IOException {
-        return readStringBuf(nullTerminated);
     }
 
     public String readStringBuf(final boolean nullTerminated) throws IOException {

--- a/src/main/java/com/rapid7/client/dcerpc/io/PacketInput.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/PacketInput.java
@@ -31,7 +31,6 @@ public class PacketInput extends PrimitiveInput {
         unmarshallable.unmarshalPreamble(this);
         unmarshallable.unmarshalEntity(this);
         unmarshallable.unmarshalDeferrals(this);
-        // TODO Align should be called, but can require resetting the packet counts
         return unmarshallable;
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/io/PacketOutput.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/PacketOutput.java
@@ -33,14 +33,13 @@ public class PacketOutput extends PrimitiveOutput {
         marshallable.marshalPreamble(this);
         marshallable.marshalEntity(this);
         marshallable.marshalDeferrals(this);
-        // TODO Align should be called, but can require resetting the packet counts
         return marshallable;
     }
 
     public void writeIntRef(final Integer value) throws IOException {
         if (value != null) {
             writeReferentID();
-            writeInt(value.intValue());
+            writeInt(value);
             align();
         } else {
             writeNull();
@@ -50,7 +49,7 @@ public class PacketOutput extends PrimitiveOutput {
     public void writeLongRef(final Long value) throws IOException {
         if (value != null) {
             writeReferentID();
-            writeLong(value.longValue());
+            writeLong(value);
             align();
         } else {
             writeNull();
@@ -86,10 +85,6 @@ public class PacketOutput extends PrimitiveOutput {
         } else {
             writeNull();
         }
-    }
-
-    public void writeRPCUnicodeString(final String string, final boolean nullTerminate) throws IOException {
-        writeStringBuffer(string, nullTerminate);
     }
 
     public void writeStringBuffer(final String string, final boolean nullTerminate) throws IOException {

--- a/src/main/java/com/rapid7/client/dcerpc/io/PrimitiveInput.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/PrimitiveInput.java
@@ -32,7 +32,7 @@ class PrimitiveInput {
 
     public PrimitiveInput(final InputStream inputStream) {
         if (inputStream == null) {
-            throw new IllegalArgumentException("Invalid InputStream: " + inputStream);
+            throw new IllegalArgumentException("Invalid InputStream: null");
         }
         dataInStream = new CountingInputStream(inputStream);
         dataIn = new LittleEndianDataInputStream(dataInStream);
@@ -94,6 +94,10 @@ class PrimitiveInput {
 
     public int readInt() throws IOException {
         return dataIn.readInt();
+    }
+
+    public long readUnsignedInt() throws IOException {
+        return readInt() & 0xFFFFFFFFL;
     }
 
     public long readLong() throws IOException {

--- a/src/main/java/com/rapid7/client/dcerpc/io/PrimitiveInput.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/PrimitiveInput.java
@@ -76,8 +76,8 @@ class PrimitiveInput {
         return dataIn.readByte();
     }
 
-    public int readUnsignedByte() throws IOException {
-        return dataIn.readUnsignedByte();
+    public char readUnsignedByte() throws IOException {
+        return (char) dataIn.readUnsignedByte();
     }
 
     public short readShort() throws IOException {

--- a/src/main/java/com/rapid7/client/dcerpc/io/PrimitiveOutput.java
+++ b/src/main/java/com/rapid7/client/dcerpc/io/PrimitiveOutput.java
@@ -31,7 +31,7 @@ public class PrimitiveOutput {
 
     public PrimitiveOutput(final OutputStream outputStream) {
         if (outputStream == null) {
-            throw new IllegalArgumentException("Invalid OutputStream: " + outputStream);
+            throw new IllegalArgumentException("Invalid OutputStream: null");
         }
         dataOutStream = new CountingOutputStream(outputStream);
         dataOut = new LittleEndianDataOutputStream(dataOutStream);
@@ -87,6 +87,10 @@ public class PrimitiveOutput {
 
     public void writeInt(final int v) throws IOException {
         dataOut.writeInt(v);
+    }
+
+    public void writeInt(final long v) throws IOException {
+        writeInt((int) v);
     }
 
     public void writeLong(final long v) throws IOException {

--- a/src/main/java/com/rapid7/client/dcerpc/objects/RPCUnicodeString.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/RPCUnicodeString.java
@@ -73,13 +73,9 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
      */
     public static class NullTerminated extends RPCUnicodeString {
         public static NullTerminated of(String value) {
-            NullTerminated str = of();
+            NullTerminated str = new NullTerminated();
             str.setValue(value);
             return str;
-        }
-
-        public static NullTerminated of() {
-            return new NullTerminated();
         }
 
         @Override

--- a/src/main/java/com/rapid7/client/dcerpc/objects/RPCUnicodeString.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/RPCUnicodeString.java
@@ -124,10 +124,10 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
         if (value == null) {
             // <NDR: unsigned short> unsigned short Length;
             // Alignment 2 - Already aligned
-            out.writeShort((short) 0);
+            out.writeShort(0);
             // <NDR: unsigned short> unsigned short MaximumLength;
             // Alignment 2 - Already aligned
-            out.writeShort((short) 0);
+            out.writeShort(0);
             // <NDR: pointer> [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer;
             // Alignment 4 - Already aligned
             out.writeNull();
@@ -137,10 +137,10 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
             final int byteLength = 2 * value.length() + (isNullTerminated() ? 2 : 0);
             // <NDR: unsigned short> unsigned short Length;
             // Alignment 2 - Already aligned
-            out.writeShort((short) byteLength);
+            out.writeShort(byteLength);
             // <NDR: unsigned short> unsigned short MaximumLength;
             // Alignment 2 - Already aligned
-            out.writeShort((short) byteLength);
+            out.writeShort(byteLength);
             // <NDR: pointer> [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer;
             // Alignment 4 - Already aligned
             out.writeReferentID();
@@ -164,7 +164,7 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
             // Alignment 1 - Already aligned
             out.writeChars(value);
             if (isNullTerminated())
-                out.writeShort((short) 0);
+                out.writeShort(0);
         }
     }
 
@@ -179,10 +179,10 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
         in.align(Alignment.FOUR);
         // <NDR: unsigned short> unsigned short Length;
         // Alignment: 2 - Already aligned
-        in.readShort();
+        in.fullySkipBytes(2);
         // <NDR: unsigned short> unsigned short MaximumLength;
         // Alignment: 2 - Already aligned
-        in.readShort();
+        in.fullySkipBytes(2);
         // <NDR: pointer> [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer;
         // Alignment: 4 - Already aligned
         if (in.readReferentID() != 0)
@@ -196,15 +196,15 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
             //Preamble
             // <NDR: unsigned long> MaximumCount for conformant array - This is *not* the size of the array, so is not useful to us
             in.align(Alignment.FOUR);
-            in.readInt();
+            in.fullySkipBytes(4);
 
             //Entity
             // <NDR: unsigned long> Offset for varying array
             // Alignment: 4 - Already aligned
-            final int offset = in.readInt();
+            final int offset = readIndex(in);
             // <NDR: unsigned long> ActualCount for varying array
             // Alignment: 4 - Already aligned
-            final int actualCount = in.readInt();
+            final int actualCount = readIndex(in);
             // If we expect a null terminator, then skip it when reading the string
             final int stringCount = (isNullTerminated() ? (actualCount - 1) : actualCount);
 
@@ -212,11 +212,8 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
             // Entities for conformant array
             final StringBuilder result = new StringBuilder(stringCount);
             // Read prefix (if any)
-            for (int i = 0; i < offset; i++) {
-                // <NDR: unsigned short>
-                // Alignment: 2 - Already aligned
-                in.readShort();
-            }
+            // Alignment: 2 - Already aligned
+            in.fullySkipBytes(2 * offset);
             // Read subset
             for (int i = 0; i < stringCount; i++) {
                 // <NDR: unsigned short>
@@ -224,11 +221,8 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
                 result.append((char) in.readShort());
             }
             // Read suffix (if any)
-            for (int i = stringCount; i < actualCount; i++) {
-                // <NDR: unsigned short>
-                // Alignment: 2 - Already aligned
-                in.readShort();
-            }
+            // Alignment: 2 - Already aligned
+            in.fullySkipBytes(2 * (actualCount-stringCount));
             this.value = result.toString();
         }
     }
@@ -255,5 +249,14 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
         return String.format("RPC_UNICODE_STRING{value:%s, nullTerminated:%b}",
                 getValue() == null ? "null" : String.format("\"%s\"", getValue()),
                 isNullTerminated());
+    }
+
+    private int readIndex(PacketInput in) throws IOException {
+        final long ret = in.readUnsignedInt();
+        // Don't allow array length or index values bigger than signed int
+        if (ret > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException(String.format("Value %d > %d", ret, Integer.MAX_VALUE));
+        }
+        return (int) ret;
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/io/Test_PrimitiveInput.java
+++ b/src/test/java/com/rapid7/client/dcerpc/io/Test_PrimitiveInput.java
@@ -352,7 +352,10 @@ public class Test_PrimitiveInput {
     public Object[][] data_readUnsignedInt() throws IOException {
         return new Object[][] {
                 {0L, "00000000"},
+                {8L, "08000000"},
                 {50462976L, "00010203"},
+                {((long)Integer.MAX_VALUE), "FFFFFF7F"},
+                {((long)Integer.MAX_VALUE)+1, "00000080"},
                 {((long)Integer.MAX_VALUE)*2 + 1, "FFFFFFFF"},
         };
     }

--- a/src/test/java/com/rapid7/client/dcerpc/io/Test_PrimitiveInput.java
+++ b/src/test/java/com/rapid7/client/dcerpc/io/Test_PrimitiveInput.java
@@ -22,21 +22,16 @@ import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class Test_PrimitiveInput {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
-    @Test
+    @Test(expectedExceptions = {IllegalArgumentException.class}, expectedExceptionsMessageRegExp = "Invalid InputStream: null")
     public void constructorNullByteBuffer() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid InputStream: null");
         new PacketInput(null);
     }
 
@@ -141,75 +136,76 @@ public class Test_PrimitiveInput {
     }
 
     @Test
+    public void getCount_readUnsignedInt() throws IOException {
+        final PacketInput packetIn = getPacketInput("00000000");
+        packetIn.readInt();
+        assertEquals(4, packetIn.getCount());
+    }
+
+    @Test
     public void getCount_readLong() throws IOException {
         final PacketInput packetIn = getPacketInput("0000000000000000");
         packetIn.readLong();
         assertEquals(8, packetIn.getCount());
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_readFully() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").readFully(new byte[1]);
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_readFullyEx() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").readFully(new byte[1], 0, 1);
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_fullySkipBytes() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").fullySkipBytes(1);
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_readBoolean() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").readBoolean();
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_readByte() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").readByte();
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_readUnsignedByte() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").readUnsignedByte();
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_readShort() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").readShort();
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_readUnsignedShort() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").readUnsignedShort();
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_readChar() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").readChar();
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_readInt() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").readInt();
     }
 
-    @Test
+    @Test(expectedExceptions = {EOFException.class})
+    public void eof_readUnsignedInt() throws IOException {
+        getPacketInput("").readUnsignedInt();
+    }
+
+    @Test(expectedExceptions = {EOFException.class})
     public void eof_readLong() throws IOException {
-        thrown.expect(EOFException.class);
         getPacketInput("").readLong();
     }
 
@@ -227,14 +223,17 @@ public class Test_PrimitiveInput {
         assertArrayEquals(new byte[]{0x00}, result);
     }
 
-    @Test
-    public void readRawBytes() throws IOException {
-        final byte[] result1 = getPacketInput("0001020304").readRawBytes(2);
-        assertArrayEquals(new byte[]{0x00, 0x01}, result1);
+    @DataProvider
+    public Object[][] data_readRawBytes() {
+        return new Object[][] {
+                {new byte[]{0x00, 0x01}, "0001020304", 2},
+                {new byte[]{0x00, 0x01, 0x02}, "0001020304", 3},
+        };
+    }
 
-        final byte[] result2 = getPacketInput("0001020304").readRawBytes(3);
-        assertArrayEquals(new byte[]{0x00, 0x01, 0x02}, result2);
-
+    @Test(dataProvider = "data_readRawBytes")
+    public void readRawBytes(byte[] expected, String hex, int count) throws IOException {
+        assertArrayEquals(expected, getPacketInput(hex).readRawBytes(count));
     }
 
     @Test
@@ -244,58 +243,139 @@ public class Test_PrimitiveInput {
         assertEquals(1, packetIn.getCount());
     }
 
-    @Test
-    public void readBoolean() throws IOException {
-        assertEquals(false, getPacketInput("00").readBoolean());
+    @DataProvider
+    public Object[][] data_readBoolean() {
+        return new Object[][] {
+                {false, "00"},
+                {true, "01"},
+                {true, "FF"},
+        };
+    }
+
+    @Test(dataProvider = "data_readBoolean")
+    public void readBoolean(boolean expected, String hex) throws IOException {
+        assertEquals(expected, getPacketInput(hex).readBoolean());
         assertEquals(true, getPacketInput("01").readBoolean());
         assertEquals(true, getPacketInput("FF").readBoolean());
     }
 
-    @Test
-    public void readByte() throws IOException {
-        assertEquals(0, getPacketInput("00").readByte());
-        assertEquals(-1, getPacketInput("FF").readByte());
+    @DataProvider
+    public Object[][] data_readByte() {
+        return new Object[][] {
+                {Byte.MIN_VALUE, "80"},
+                {0, "00"},
+                {13, "0D"},
+                {-1, "FF"},
+                {Byte.MAX_VALUE, "7F"}
+        };
     }
 
-    @Test
-    public void readUnsignedByte() throws IOException {
-        assertEquals(0, getPacketInput("00").readUnsignedByte());
-        assertEquals(255, getPacketInput("FF").readUnsignedByte());
+    @Test(dataProvider = "data_readByte")
+    public void readByte(int expected, String hex) throws IOException {
+        assertEquals(expected, getPacketInput(hex).readByte());
     }
 
-    @Test
-    public void readShort() throws IOException {
-        assertEquals(0, getPacketInput("0000").readShort());
-        assertEquals(256, getPacketInput("0001").readShort());
-        assertEquals(-1, getPacketInput("FFFF").readShort());
+    @DataProvider
+    public Object[][] data_readUnsignedByte() {
+        return new Object[][] {
+                {0, "00"},
+                {13, "0D"},
+                {(Byte.MAX_VALUE*2)+1, "FF"}
+        };
     }
 
-    @Test
-    public void readUnsignedShort() throws IOException {
-        assertEquals(0, getPacketInput("0000").readUnsignedShort());
-        assertEquals(256, getPacketInput("0001").readUnsignedShort());
-        assertEquals(65535, getPacketInput("FFFF").readUnsignedShort());
+    @Test(dataProvider = "data_readUnsignedByte")
+    public void readUnsignedByte(int expected, String hex) throws IOException {
+        assertEquals(expected, getPacketInput(hex).readUnsignedByte());
     }
 
-    @Test
-    public void readChar() throws IOException {
-        assertEquals(0, getPacketInput("0000").readChar());
-        assertEquals(256, getPacketInput("0001").readChar());
-        assertEquals(65535, getPacketInput("FFFF").readChar());
+    @DataProvider
+    public Object[][] data_readShort() {
+        return new Object[][] {
+                {Short.MIN_VALUE, "0080"},
+                {(short) 0, "0000"},
+                {(short) 256, "0001"},
+                {Short.MAX_VALUE, "FF7F"},
+        };
     }
 
-    @Test
-    public void readInt() throws IOException {
-        assertEquals(0, getPacketInput("00000000").readInt());
-        assertEquals(50462976, getPacketInput("00010203").readInt());
-        assertEquals(-1, getPacketInput("FFFFFFFF").readInt());
+    @Test(dataProvider = "data_readShort")
+    public void readShort(short expected, String hex) throws IOException {
+        assertEquals(expected, getPacketInput(hex).readShort());
     }
 
-    @Test
-    public void readLong() throws IOException {
-        assertEquals(0, getPacketInput("0000000000000000").readLong());
-        assertEquals(506097522914230528l, getPacketInput("0001020304050607").readLong());
-        assertEquals(-1, getPacketInput("FFFFFFFFFFFFFFFF").readLong());
+    @DataProvider
+    public Object[][] data_readUnsignedShort() {
+        return new Object[][] {
+                {0, "0000"},
+                {256, "0001"},
+                {(Short.MAX_VALUE*2) + 1, "FFFF"},
+        };
+    }
+
+    @Test(dataProvider = "data_readUnsignedShort")
+    public void readUnsignedShort(int expected, String hex) throws IOException {
+        assertEquals(expected, getPacketInput(hex).readUnsignedShort());
+    }
+
+    @DataProvider
+    public Object[][] data_readChar() {
+        return new Object[][] {
+                {(char) 0, "0000"},
+                {(char) 256, "0001"},
+                {(char) ((Short.MAX_VALUE*2) + 1), "FFFF"},
+        };
+    }
+
+    @Test(dataProvider = "data_readChar")
+    public void readChar(char expected, String hex) throws IOException {
+        assertEquals(expected, getPacketInput(hex).readChar());
+    }
+
+    @DataProvider
+    public Object[][] data_readInt() {
+        return new Object[][] {
+                {Integer.MIN_VALUE, "00000080"},
+                {0, "00000000"},
+                {50462976, "00010203"},
+                {-1, "FFFFFFFF"},
+                {Integer.MAX_VALUE, "FFFFFF7F"}
+        };
+    }
+
+    @Test(dataProvider = "data_readInt")
+    public void readInt(int expected, String hex) throws IOException {
+        assertEquals(expected, getPacketInput(hex).readInt());
+    }
+
+    @DataProvider
+    public Object[][] data_readUnsignedInt() throws IOException {
+        return new Object[][] {
+                {0L, "00000000"},
+                {50462976L, "00010203"},
+                {((long)Integer.MAX_VALUE)*2 + 1, "FFFFFFFF"},
+        };
+    }
+
+    @Test(dataProvider = "data_readUnsignedInt")
+    public void readUnsignedInt(long expected, String hex) throws IOException {
+        assertEquals(expected, getPacketInput(hex).readUnsignedInt());
+    }
+
+    @DataProvider
+    public Object[][] data_readLong() {
+        return new Object[][] {
+                {Long.MIN_VALUE, "0000000000000080"},
+                {0, "0000000000000000"},
+                {506097522914230528L, "0001020304050607"},
+                {-1, "FFFFFFFFFFFFFFFF"},
+                {Long.MAX_VALUE, "FFFFFFFFFFFFFF7F"}
+        };
+    }
+
+    @Test(dataProvider = "data_readLong")
+    public void readLong(long expected, String hex) throws IOException {
+        assertEquals(expected, getPacketInput(hex).readLong());
     }
 
     private PacketInput getPacketInput(final String hexString) {

--- a/src/test/java/com/rapid7/client/dcerpc/io/Test_PrimitiveInput.java
+++ b/src/test/java/com/rapid7/client/dcerpc/io/Test_PrimitiveInput.java
@@ -263,29 +263,29 @@ public class Test_PrimitiveInput {
     public Object[][] data_readByte() {
         return new Object[][] {
                 {Byte.MIN_VALUE, "80"},
-                {0, "00"},
-                {13, "0D"},
-                {-1, "FF"},
+                {(byte) 0, "00"},
+                {(byte) 13, "0D"},
+                {(byte) -1, "FF"},
                 {Byte.MAX_VALUE, "7F"}
         };
     }
 
     @Test(dataProvider = "data_readByte")
-    public void readByte(int expected, String hex) throws IOException {
+    public void readByte(byte expected, String hex) throws IOException {
         assertEquals(expected, getPacketInput(hex).readByte());
     }
 
     @DataProvider
     public Object[][] data_readUnsignedByte() {
         return new Object[][] {
-                {0, "00"},
-                {13, "0D"},
-                {(Byte.MAX_VALUE*2)+1, "FF"}
+                {(short) 0, "00"},
+                {(short) 13, "0D"},
+                {(short) ((Byte.MAX_VALUE*2)+1), "FF"}
         };
     }
 
     @Test(dataProvider = "data_readUnsignedByte")
-    public void readUnsignedByte(int expected, String hex) throws IOException {
+    public void readUnsignedByte(short expected, String hex) throws IOException {
         assertEquals(expected, getPacketInput(hex).readUnsignedByte());
     }
 

--- a/src/test/java/com/rapid7/client/dcerpc/io/Test_PrimitiveOutput.java
+++ b/src/test/java/com/rapid7/client/dcerpc/io/Test_PrimitiveOutput.java
@@ -192,6 +192,7 @@ public class Test_PrimitiveOutput {
                 // Signed
                 {(long) Integer.MIN_VALUE, "00000080"},
                 {0L, "00000000"},
+                {8L, "08000000"},
                 {50462976L, "00010203"},
                 {(long) Integer.MAX_VALUE, "FFFFFF7F"},
                 // Unsigned

--- a/src/test/java/com/rapid7/client/dcerpc/io/Test_PrimitiveOutput.java
+++ b/src/test/java/com/rapid7/client/dcerpc/io/Test_PrimitiveOutput.java
@@ -21,20 +21,15 @@ package com.rapid7.client.dcerpc.io;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class Test_PrimitiveOutput {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
-    @Test
+    @Test(expectedExceptions = {IllegalArgumentException.class}, expectedExceptionsMessageRegExp = "Invalid OutputStream: null")
     public void constructorNullByteBuffer() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid OutputStream: null");
         new PacketOutput(null);
     }
 
@@ -61,6 +56,24 @@ public class Test_PrimitiveOutput {
 
         packetOut.align();
         assertEquals(8, packetOut.getCount());
+    }
+
+    @DataProvider
+    public Object[][] data_pad() {
+        return new Object[][] {
+                {0, ""},
+                {1, "00"},
+                {2, "0000"},
+                {4, "00000000"},
+                {8, "0000000000000000"},
+        };
+    }
+
+    @Test(dataProvider = "data_pad")
+    public void pad(long n, String expectedHex) throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        new PacketOutput(outputStream).pad(n);
+        assertEquals(expectedHex, Hex.toHexString(outputStream.toByteArray()).toUpperCase());
     }
 
     @Test
@@ -110,49 +123,106 @@ public class Test_PrimitiveOutput {
     public void writeByte() throws IOException {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final PacketOutput packetOut = new PacketOutput(outputStream);
-        packetOut.writeByte(0);
-        packetOut.writeByte(0xFF);
+        packetOut.writeByte((byte) 0);
+        packetOut.writeByte((byte) 0xFF);
         assertEquals("00FF", Hex.toHexString(outputStream.toByteArray()).toUpperCase());
     }
 
-    @Test
-    public void writeShort() throws IOException {
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        final PacketOutput packetOut = new PacketOutput(outputStream);
-        packetOut.writeShort(0);
-        packetOut.writeShort(256);
-        packetOut.writeShort(0xFFFF);
-        assertEquals("00000001FFFF", Hex.toHexString(outputStream.toByteArray()).toUpperCase());
+    @DataProvider
+    public Object[][] data_writeShort() {
+        return new Object[][] {
+                // Signed
+                {Short.MIN_VALUE, "0080"},
+                {-50, "CEFF"},
+                {0, "0000"},
+                {256, "0001"},
+                {Short.MAX_VALUE, "FF7F"},
+                // Unsigned
+                {Short.MAX_VALUE+1, "0080"},
+                {Short.MAX_VALUE*2, "FEFF"},
+                {Short.MAX_VALUE*2 + 1, "FFFF"}
+        };
     }
 
-    @Test
-    public void writeChar() throws IOException {
+    @Test(dataProvider = "data_writeShort")
+    public void writeShort(int value, String expectedHex) throws IOException {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        final PacketOutput packetOut = new PacketOutput(outputStream);
-        packetOut.writeChar(0);
-        packetOut.writeChar(256);
-        packetOut.writeChar(0xFFFF);
-        assertEquals("00000001FFFF", Hex.toHexString(outputStream.toByteArray()).toUpperCase());
+        new PacketOutput(outputStream).writeShort(value);
+        assertEquals(expectedHex, Hex.toHexString(outputStream.toByteArray()).toUpperCase());
     }
 
-    @Test
-    public void writeInt() throws IOException {
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        final PacketOutput packetOut = new PacketOutput(outputStream);
-        packetOut.writeInt(0);
-        packetOut.writeInt(50462976);
-        packetOut.writeInt(0xFFFFFFFF);
-        assertEquals("0000000000010203FFFFFFFF", Hex.toHexString(outputStream.toByteArray()).toUpperCase());
+    @DataProvider
+    public Object[][] data_writeChar() {
+        return new Object[][] {
+                {Character.MIN_VALUE, "0000"},
+                {50, "3200"},
+                {256, "0001"},
+                {Character.MAX_VALUE, "FFFF"},
+        };
     }
 
-    @Test
-    public void writeLong() throws IOException {
+    @Test(dataProvider = "data_writeChar")
+    public void writeChar(int value, String expectedHex) throws IOException {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        final PacketOutput packetOut = new PacketOutput(outputStream);
-        packetOut.writeLong(0);
-        packetOut.writeLong(506097522914230528l);
-        packetOut.writeLong(0xFFFFFFFFFFFFFFFFl);
-        assertEquals("00000000000000000001020304050607FFFFFFFFFFFFFFFF", Hex.toHexString(outputStream.toByteArray()).toUpperCase());
+        new PacketOutput(outputStream).writeChar(value);
+        assertEquals(expectedHex, Hex.toHexString(outputStream.toByteArray()).toUpperCase());
+    }
+
+    @DataProvider
+    public Object[][] data_writeInt() {
+        return new Object[][] {
+                {Integer.MIN_VALUE, "00000080"},
+                {0, "00000000"},
+                {50, "32000000"},
+                {50462976, "00010203"},
+                {Integer.MAX_VALUE, "FFFFFF7F"}
+        };
+    }
+
+    @Test(dataProvider = "data_writeInt")
+    public void writeInt(int value, String expectedHex) throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        new PacketOutput(outputStream).writeInt(value);
+        assertEquals(expectedHex, Hex.toHexString(outputStream.toByteArray()).toUpperCase());
+    }
+
+    @DataProvider
+    public Object[][] data_writeInt_long() {
+        return new Object[][] {
+                // Signed
+                {(long) Integer.MIN_VALUE, "00000080"},
+                {0L, "00000000"},
+                {50462976L, "00010203"},
+                {(long) Integer.MAX_VALUE, "FFFFFF7F"},
+                // Unsigned
+                {(long) Integer.MAX_VALUE+1, "00000080"},
+                {(long) Integer.MAX_VALUE*2, "FEFFFFFF"},
+                {(long) Integer.MAX_VALUE*2 + 1, "FFFFFFFF"}
+        };
+    }
+
+    @Test(dataProvider = "data_writeInt_long")
+    public void writeInt_long(long value, String expectedHex) throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        new PacketOutput(outputStream).writeInt(value);
+        assertEquals(expectedHex, Hex.toHexString(outputStream.toByteArray()).toUpperCase());
+    }
+
+    @DataProvider
+    public Object[][] data_writeLong() {
+        return new Object[][] {
+                {Long.MIN_VALUE, "0000000000000080"},
+                {0L, "0000000000000000"},
+                {50L, "3200000000000000"},
+                {Long.MAX_VALUE, "FFFFFFFFFFFFFF7F"},
+        };
+    }
+
+    @Test(dataProvider = "data_writeLong")
+    public void writeLong(long value, String expectedHex) throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        new PacketOutput(outputStream).writeLong(value);
+        assertEquals(expectedHex, Hex.toHexString(outputStream.toByteArray()).toUpperCase());
     }
 
     @Test
@@ -168,6 +238,7 @@ public class Test_PrimitiveOutput {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final PacketOutput packetOut = new PacketOutput(outputStream);
         packetOut.writeChars("Hello World");
-        assertEquals("480065006C006C006F00200057006F0072006C006400", Hex.toHexString(outputStream.toByteArray()).toUpperCase());
+        assertEquals("480065006C006C006F00200057006F0072006C006400",
+                Hex.toHexString(outputStream.toByteArray()).toUpperCase());
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/objects/Test_RPCSID.java
+++ b/src/test/java/com/rapid7/client/dcerpc/objects/Test_RPCSID.java
@@ -140,20 +140,20 @@ public class Test_RPCSID {
         RPCSID rpc_sid = new RPCSID();
         rpc_sid.unmarshalPreamble(in);
         assertEquals(bin.available(), 0);
-        assertEquals(rpc_sid.getSubAuthority(), new long[2]);
+        assertEquals(rpc_sid.getSubAuthority(), null);
     }
 
     @DataProvider
     public Object[][] data_unmarshalEntity() {
         return new Object[][] {
                 // Alignment: 0
-                {"1902010203040506050000000a000000", 0},
+                {"190201020304050605000000000000a0", 0},
                 // Alignment: 3
-                {"ffffffff1902010203040506050000000a000000", 1},
+                {"ffffffff190201020304050605000000000000a0", 1},
                 // Alignment: 2
-                {"ffffffff1902010203040506050000000a000000", 2},
+                {"ffffffff190201020304050605000000000000a0", 2},
                 // Alignment: 1
-                {"ffffffff1902010203040506050000000a000000", 3},
+                {"ffffffff190201020304050605000000000000a0", 3},
         };
     }
 
@@ -170,22 +170,7 @@ public class Test_RPCSID {
         assertEquals(rpc_sid.getRevision(), (char) 25);
         assertEquals(rpc_sid.getSubAuthorityCount(), (char) 2);
         assertEquals(rpc_sid.getIdentifierAuthority(), new byte[]{1, 2, 3, 4, 5, 6});
-        assertEquals(rpc_sid.getSubAuthority(), new long[]{5L, 10L});
-    }
-
-    @Test
-    public void test_unmarshalEntity_SubAuthorityCountInvalid() throws IOException {
-        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode("191e010203040506050000000a000000"));
-        RPCSID rpc_sid = new RPCSID();
-        rpc_sid.setSubAuthority(new long[2]);
-        IllegalArgumentException actual = null;
-        try {
-            rpc_sid.unmarshalEntity(new PacketInput(bin));
-        } catch (IllegalArgumentException e) {
-            actual = e;
-        }
-        assertNotNull(actual);
-        assertEquals(actual.getMessage(), "SubAuthorityCount (30) != SubAuthority[] length (2)");
+        assertEquals(rpc_sid.getSubAuthority(), new long[]{5L, 2684354560L});
     }
 
     @Test


### PR DESCRIPTION
- Uses appropriate return type for: `PacketInput.readUnsignedByte()`
- Adds convenience method: `PacketInput.readUnsignedInt()`
- Adds convenience method: `PacketOutput.writeInt(long)`
- Adds full unit test coverage including signed/unsigned parameters for `PacketInput`/`PacketOutput`
- Improves `RPCUnicodeString` and `RPCSID`:
  * Each of these structs now read/write unsigned primitives where required
  * Now skipping bytes instead of parsing numbers where the values are not used