### PR TITLE
Adds SamrQueryInformationGroup with level 1 support (SAMPR_GROUP_GENERAL_INFORMATION)

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
@@ -47,12 +47,14 @@ import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenGroupRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenGroupResponse;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenUserRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenUserResponse;
+import com.rapid7.client.dcerpc.mssamr.messages.SamrQueryInformationGroupRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrQueryInformationUserRequest;
 import com.rapid7.client.dcerpc.mssamr.objects.AliasHandle;
 import com.rapid7.client.dcerpc.mssamr.objects.AliasInfo;
 import com.rapid7.client.dcerpc.mssamr.objects.DomainHandle;
 import com.rapid7.client.dcerpc.mssamr.objects.DomainInfo;
 import com.rapid7.client.dcerpc.mssamr.objects.GroupHandle;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRGroupGeneralInformation;
 import com.rapid7.client.dcerpc.mssamr.objects.SAMPRUserAllInformation;
 import com.rapid7.client.dcerpc.mssamr.objects.GroupInfo;
 import com.rapid7.client.dcerpc.mssamr.objects.ServerHandle;
@@ -150,6 +152,11 @@ public class SecurityAccountManagerService {
     public SAMPRUserAllInformation getUserAllInformation(final UserHandle userHandle) throws IOException {
         SamrQueryInformationUserRequest.UserAllInformation request = new SamrQueryInformationUserRequest.UserAllInformation(userHandle);
         return transport.call(request).getUserInformation();
+    }
+
+    public SAMPRGroupGeneralInformation getGroupGeneralInformation(final GroupHandle groupHandle) throws IOException {
+        SamrQueryInformationGroupRequest.GroupGeneralInformation request = new SamrQueryInformationGroupRequest.GroupGeneralInformation(groupHandle);
+        return transport.call(request).getGroupInformation();
     }
 
     /**

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationGroupRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationGroupRequest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+import com.rapid7.client.dcerpc.messages.RequestCall;
+import com.rapid7.client.dcerpc.mssamr.objects.GroupHandle;
+import com.rapid7.client.dcerpc.mssamr.objects.GroupInformationClass;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRGroupGeneralInformation;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRUserAllInformation;
+import com.rapid7.client.dcerpc.mssamr.objects.UserHandle;
+import com.rapid7.client.dcerpc.mssamr.objects.UserInformationClass;
+
+/**
+ * <a href="https://msdn.microsoft.com/en-us/library/cc245780.aspx">SamrQueryInformationGroup</a>
+ *
+ * <blockquote><pre>The SamrQueryInformationGroup method obtains attributes from a group object.
+ *      long SamrQueryInformationGroup(
+ *          [in] SAMPR_HANDLE GroupHandle,
+ *          [in] GROUP_INFORMATION_CLASS GroupInformationClass,
+ *          [out, switch_is(GroupInformationClass)]
+ *          PSAMPR_GROUP_INFO_BUFFER* Buffer
+ *      );
+ *  GroupHandle: An RPC context handle, as specified in section 2.2.3.2, representing a group object.
+ *  GroupInformationClass: An enumeration indicating which attributes to return. See section 2.2.5.6 for a listing of possible values.
+ *  Buffer: The requested attributes on output. See section 2.2.5.7 for structure details.
+ *
+ *  This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject the use of context handles created by a method of a different RPC interface than this one, as specified in [MS-RPCE] section 3.
+ *  Upon receiving this message, the server MUST process the data from the message subject to the following constraints:
+ *
+ *  1. The server MUST return an error if GroupHandle.HandleType is not equal to "Group".
+ *  2. GroupHandle.GrantedAccess MUST have the required access specified in section 3.1.2.1. Otherwise, the server MUST return STATUS_ACCESS_DENIED.
+ *  3. The following information levels MUST be processed by setting the appropriate output field name to either the associated database attribute or the value resulting from the associated processing rules, as specified in section 3.1.5.14.9. Processing is completed by returning 0 on success.
+ *      GroupGeneralInformation
+ *      GroupNameInformation
+ *      GroupAttributeInformation
+ *      GroupAdminCommentInformation
+ *  4. If GroupInformationClass does not meet the criteria of constraint 3, the constraints associated with the GroupInformationClass input value in the following subsections MUST be satisfied; if there is no subsection for the GroupInformationClass value, an error MUST be returned to the client.</pre></blockquote>
+ */
+public abstract class SamrQueryInformationGroupRequest<T extends Unmarshallable> extends RequestCall<SamrQueryInformationGroupResponse<T>> {
+    public static final short OP_NUM = 20;
+
+    private final GroupHandle groupHandle;
+
+    SamrQueryInformationGroupRequest(GroupHandle groupHandle) {
+        super(OP_NUM);
+        this.groupHandle = groupHandle;
+    }
+
+    public GroupHandle getGroupHandle() {
+        return groupHandle;
+    }
+
+    public abstract GroupInformationClass getGroupInformationClass();
+
+    @Override
+    public void marshal(PacketOutput packetOut) throws IOException {
+        // <NDR: struct> [in] SAMPR_HANDLE GroupHandle,
+        packetOut.writeMarshallable(getGroupHandle());
+        // <NDR: unsigned short> [in] GROUP_INFORMATION_CLASS GroupInformationClass,
+        // Alignment: 2 - Already aligned. ContextHandle writes 20 bytes above
+        packetOut.writeShort(getGroupInformationClass().getInfoLevel());
+    }
+
+    public static class GroupGeneralInformation extends SamrQueryInformationGroupRequest<SAMPRGroupGeneralInformation> {
+        public GroupGeneralInformation(GroupHandle groupHandle) {
+            super(groupHandle);
+        }
+
+        @Override
+        public GroupInformationClass getGroupInformationClass() {
+            return GroupInformationClass.GROUP_GENERAL_INFORMATION;
+        }
+
+        @Override
+        public SamrQueryInformationGroupResponse.GroupGeneralInformation getResponseObject() {
+            return new SamrQueryInformationGroupResponse.GroupGeneralInformation();
+        }
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationGroupResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationGroupResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import java.rmi.UnmarshalException;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+import com.rapid7.client.dcerpc.messages.RequestResponse;
+import com.rapid7.client.dcerpc.mssamr.objects.GroupInformationClass;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRGroupGeneralInformation;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRUserAllInformation;
+import com.rapid7.client.dcerpc.mssamr.objects.UserInformationClass;
+
+public abstract class SamrQueryInformationGroupResponse<T extends Unmarshallable> extends RequestResponse {
+    private T groupInformation;
+
+    public T getGroupInformation() {
+        return groupInformation;
+    }
+
+    public abstract GroupInformationClass getGroupInformationClass();
+
+    abstract T createGroupInformation();
+
+    @Override
+    public void unmarshal(PacketInput packetIn) throws IOException {
+        if(packetIn.readReferentID() != 0) {
+            final int infoLevel = packetIn.readUnsignedShort();
+            if (infoLevel != getGroupInformationClass().getInfoLevel()) {
+                throw new UnmarshalException(String.format(
+                        "Incoming GROUP_INFORMATION_CLASS %d does not match expected: %d",
+                        infoLevel, getGroupInformationClass().getInfoLevel()));
+            }
+            this.groupInformation = createGroupInformation();
+            packetIn.readUnmarshallable(this.groupInformation);
+        } else {
+            this.groupInformation = null;
+        }
+    }
+
+    public static class GroupGeneralInformation extends SamrQueryInformationGroupResponse<SAMPRGroupGeneralInformation> {
+        @Override
+        public GroupInformationClass getGroupInformationClass() {
+            return GroupInformationClass.GROUP_GENERAL_INFORMATION;
+        }
+
+        @Override
+        SAMPRGroupGeneralInformation createGroupInformation() {
+            return new SAMPRGroupGeneralInformation();
+        }
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/GroupInformationClass.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/GroupInformationClass.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+/** *
+ * <b>Alignment: 2</b>
+ * <br>
+ * <a href="https://msdn.microsoft.com/en-us/library/cc245586.aspx">GROUP_INFORMATION_CLASS</a>
+ * <blockquote><pre>The GROUP_INFORMATION_CLASS enumeration indicates how to interpret the Buffer parameter for SamrSetInformationGroup and SamrQueryInformationGroup. For a list of associated structures, see section 2.2.5.7.
+ *      typedef  enum _GROUP_INFORMATION_CLASS
+ *      {
+ *          GroupGeneralInformation = 1,
+ *          GroupNameInformation,
+ *          GroupAttributeInformation,
+ *          GroupAdminCommentInformation,
+ *          GroupReplicationInformation
+ *          } GROUP_INFORMATION_CLASS;
+ *  GroupGeneralInformation:  Indicates the Buffer parameter is to be interpreted as a SAMPR_GROUP_GENERAL_INFORMATION structure (see section 2.2.5.3).
+ *  GroupNameInformation:  Indicates the Buffer parameter is to be interpreted as a SAMPR_GROUP_NAME_INFORMATION structure (see section 2.2.5.4).
+ *  GroupAttributeInformation:  Indicates the Buffer parameter is to be interpreted as a SAMPR_GROUP_ATTRIBUTE_INFORMATION structure (see section 2.2.5.2).
+ *  GroupAdminCommentInformation:  Indicates the Buffer parameter is to be interpreted as a SAMPR_GROUP_ADM_COMMENT_INFORMATION structure (see section 2.2.5.5).
+ *  GroupReplicationInformation:  Indicates the Buffer parameter is to be interpreted as a SAMPR_GROUP_GENERAL_INFORMATION structure (see section 2.2.5.3).</pre></blockquote>
+ */
+public enum GroupInformationClass {
+    GROUP_GENERAL_INFORMATION(1);
+
+    private final int infoLevel;
+
+    GroupInformationClass(final int infoLevel) {
+        this.infoLevel = infoLevel;
+    }
+
+    public int getInfoLevel() {
+        return infoLevel;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("GROUP_INFORMATION_CLASS{name:%s, infoLevel:%d}", name(), getInfoLevel());
+    }
+
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRGroupGeneralInformation.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRGroupGeneralInformation.java
@@ -29,7 +29,7 @@ import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
 import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 
 /**
- * <b>Alignment: 8</b><pre>
+ * <b>Alignment: 4</b><pre>
  *     RPC_UNICODE_STRING Name;: 4
  *     unsigned long Attributes;: 4
  *     unsigned long MemberCount;: 4

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRGroupGeneralInformation.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRGroupGeneralInformation.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+import java.io.IOException;
+import java.util.Objects;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
+
+/**
+ * <b>Alignment: 8</b><pre>
+ *     RPC_UNICODE_STRING Name;: 4
+ *     unsigned long Attributes;: 4
+ *     unsigned long MemberCount;: 4
+ *     RPC_UNICODE_STRING AdminComment;: 4</pre>
+ * <a href="https://msdn.microsoft.com/en-us/library/cc245583.aspx">SAMPR_GROUP_GENERAL_INFORMATION</a>
+ * <blockquote><pre>The SAMPR_GROUP_GENERAL_INFORMATION structure contains group fields.
+ *      typedef struct _SAMPR_GROUP_GENERAL_INFORMATION {
+ *          RPC_UNICODE_STRING Name;
+ *          unsigned long Attributes;
+ *          unsigned long MemberCount;
+ *          RPC_UNICODE_STRING AdminComment;
+ *      } SAMPR_GROUP_GENERAL_INFORMATION,
+ *      *PSAMPR_GROUP_GENERAL_INFORMATION;
+ *  For information on each field, see section 2.2.5.1.</pre></blockquote>
+ */
+public class SAMPRGroupGeneralInformation implements Unmarshallable {
+    // <NDR: struct> RPC_UNICODE_STRING Name;
+    private RPCUnicodeString.NonNullTerminated name;
+    // <NDR: unsigned long> unsigned long Attributes;
+    private long attributes;
+    // <NDR: unsigned long> unsigned long MemberCount;
+    private long memberCount;
+    // <NDR: struct> RPC_UNICODE_STRING AdminComment;
+    private RPCUnicodeString.NonNullTerminated adminComment;
+
+    public RPCUnicodeString.NonNullTerminated getName() {
+        return name;
+    }
+
+    public void setName(RPCUnicodeString.NonNullTerminated name) {
+        this.name = name;
+    }
+
+    public long getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(long attributes) {
+        this.attributes = attributes;
+    }
+
+    public long getMemberCount() {
+        return memberCount;
+    }
+
+    public void setMemberCount(long memberCount) {
+        this.memberCount = memberCount;
+    }
+
+    public RPCUnicodeString.NonNullTerminated getAdminComment() {
+        return adminComment;
+    }
+
+    public void setAdminComment(RPCUnicodeString.NonNullTerminated adminComment) {
+        this.adminComment = adminComment;
+    }
+
+    @Override
+    public void unmarshalPreamble(PacketInput in) throws IOException {
+        // <NDR: struct> RPC_UNICODE_STRING Name;
+        name = new RPCUnicodeString.NonNullTerminated();
+        name.unmarshalPreamble(in);
+        // <NDR: struct> RPC_UNICODE_STRING AdminComment;
+        adminComment = new RPCUnicodeString.NonNullTerminated();
+        adminComment.unmarshalPreamble(in);
+    }
+
+    @Override
+    public void unmarshalEntity(PacketInput in) throws IOException {
+        // Structure Alignment: 4
+        in.align(Alignment.FOUR);
+        // <NDR: struct> RPC_UNICODE_STRING Name;
+        name.unmarshalEntity(in);
+        // <NDR: unsigned long> unsigned long Attributes;
+        in.align(Alignment.FOUR);
+        attributes = in.readUnsignedInt();
+        // <NDR: unsigned long> unsigned long MemberCount;
+        // Alignment: 4 - Already aligned
+        memberCount = in.readUnsignedInt();
+        // <NDR: struct> RPC_UNICODE_STRING AdminComment;
+        adminComment.unmarshalEntity(in);
+    }
+
+    @Override
+    public void unmarshalDeferrals(PacketInput in) throws IOException {
+        // <NDR: struct> RPC_UNICODE_STRING Name;
+        name.unmarshalDeferrals(in);
+        // <NDR: struct> RPC_UNICODE_STRING AdminComment;
+        adminComment.unmarshalDeferrals(in);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getAttributes(), getMemberCount(), getAdminComment());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (! (obj instanceof SAMPRGroupGeneralInformation)) {
+            return false;
+        }
+        SAMPRGroupGeneralInformation other = (SAMPRGroupGeneralInformation) obj;
+        return Objects.equals(getName(), other.getName())
+                && Objects.equals(getAttributes(), other.getAttributes())
+                && Objects.equals(getMemberCount(), other.getMemberCount())
+                && Objects.equals(getAdminComment(), other.getAdminComment());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("SAMPR_GROUP_GENERAL_INFORMATION{Name:%s,Attributes:%d,MemberCount:%d,AdminComment:%s}",
+                getName(), getAttributes(), getMemberCount(), getAdminComment());
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationGroupRequest.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationGroupRequest.java
@@ -28,42 +28,42 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import com.rapid7.client.dcerpc.io.PacketInput;
 import com.rapid7.client.dcerpc.io.PacketOutput;
-import com.rapid7.client.dcerpc.mssamr.objects.UserHandle;
+import com.rapid7.client.dcerpc.mssamr.objects.GroupHandle;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-public class Test_SamrQueryInformationUserRequest {
+public class Test_SamrQueryInformationGroupRequest {
 
     @DataProvider
     public Object[][] data_requests() {
-        UserHandle handle = new UserHandle();
+        GroupHandle handle = new GroupHandle();
         handle.setBytes(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20});
         return new Object[][] {
-                {new SamrQueryInformationUserRequest.UserAllInformation(handle)}
+                {new SamrQueryInformationGroupRequest.GroupGeneralInformation(handle)}
         };
     }
 
     @Test(dataProvider = "data_requests")
-    public void test_getOpNum(SamrQueryInformationUserRequest request) {
-        assertEquals(request.getOpNum(), SamrQueryInformationUserRequest.OP_NUM);
+    public void test_getOpNum(SamrQueryInformationGroupRequest request) {
+        assertEquals(request.getOpNum(), SamrQueryInformationGroupRequest.OP_NUM);
     }
 
     @Test(dataProvider = "data_requests")
-    public void test_getResponseObject(SamrQueryInformationUserRequest request) {
+    public void test_getResponseObject(SamrQueryInformationGroupRequest request) {
         assertNotNull(request.getResponseObject());
     }
 
     @Test(dataProvider = "data_requests")
-    public void test_marshall(SamrQueryInformationUserRequest request) throws IOException {
+    public void test_marshall(SamrQueryInformationGroupRequest request) throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         PacketOutput out = new PacketOutput(bout);
         request.marshal(out);
 
         ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
         PacketInput in = new PacketInput(bin);
-        assertEquals(in.readRawBytes(20), request.getUserHandle().getBytes());
-        assertEquals(in.readUnsignedShort(), request.getUserInformationClass().getInfoLevel());
+        assertEquals(in.readRawBytes(20), request.getGroupHandle().getBytes());
+        assertEquals(in.readUnsignedShort(), request.getGroupInformationClass().getInfoLevel());
         assertEquals(bin.available(), 0);
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationGroupResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationGroupResponse.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.rmi.UnmarshalException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+import com.rapid7.client.dcerpc.mssamr.objects.GroupInformationClass;
+import com.rapid7.client.dcerpc.mssamr.objects.UserInformationClass;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+public class Test_SamrQueryInformationGroupResponse {
+
+    @DataProvider
+    public Object[][] data_getters() {
+        return new Object[][] {
+                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), GroupInformationClass.GROUP_GENERAL_INFORMATION}
+        };
+    }
+
+    @Test(dataProvider = "data_getters")
+    public void test_getters(SamrQueryInformationGroupResponse response, GroupInformationClass expectedGroupInformationClass) {
+        assertNull(response.getGroupInformation());
+        assertSame(response.getGroupInformationClass(), expectedGroupInformationClass);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshal() {
+        return new Object[][] {
+                // Reference: 1, USER_INFORMATION_CLASS: 21
+                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "01000000 0100"}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshal")
+    public void test_unmarshal(SamrQueryInformationGroupResponse response, String hex) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = spy(new PacketInput(bin));
+        doReturn(null).when(in).readUnmarshallable(any(Unmarshallable.class));
+        response.unmarshal(in);
+        assertNotNull(response.getGroupInformation());
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshall_Null() {
+        return new Object[][] {
+                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "00000000 0100"}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshall_Null")
+    public void test_unmarshall_Null(SamrQueryInformationGroupResponse response, String hex) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = spy(new PacketInput(bin));
+        response.unmarshal(in);
+        assertNull(response.getGroupInformation());
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshal_InvalidTag() {
+        return new Object[][] {
+                // Reference: 1, POLICY_CLASS_INFORMATION: 3
+                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "01000000 FFFF"},
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshal_InvalidTag",
+            expectedExceptions = {UnmarshalException.class},
+            expectedExceptionsMessageRegExp = "Incoming GROUP_INFORMATION_CLASS 65535 does not match expected: [0-9]+")
+    public void test_unmarshal_InvalidTag(SamrQueryInformationGroupResponse response, String hex) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = spy(new PacketInput(bin));
+        response.unmarshal(in);
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_GroupInformationClass.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_GroupInformationClass.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class Test_GroupInformationClass {
+    @DataProvider
+    public Object[][] data_getInfoLevel() {
+        return new Object[][] {
+                {GroupInformationClass.GROUP_GENERAL_INFORMATION, 1}
+        };
+    }
+
+    @Test(dataProvider = "data_getInfoLevel")
+    public void test_getInfoLevel(GroupInformationClass obj, int expected) {
+        assertEquals(obj.getInfoLevel(), expected);
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRGroupGeneralInformation.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRGroupGeneralInformation.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+public class Test_SAMPRGroupGeneralInformation {
+
+    @Test
+    public void test_getters() {
+        SAMPRGroupGeneralInformation obj = new SAMPRGroupGeneralInformation();
+        assertNull(obj.getName());
+        assertEquals(obj.getAttributes(), 0L);
+        assertEquals(obj.getMemberCount(), 0L);
+        assertNull(obj.getAdminComment());
+    }
+
+    @Test
+    public void test_setters() {
+        SAMPRGroupGeneralInformation obj = new SAMPRGroupGeneralInformation();
+        RPCUnicodeString.NonNullTerminated name = RPCUnicodeString.NonNullTerminated.of("Name");
+        obj.setName(name);
+        obj.setAttributes(50L);
+        obj.setMemberCount(100L);
+        RPCUnicodeString.NonNullTerminated adminComment = RPCUnicodeString.NonNullTerminated.of("AdminComment");
+        obj.setAdminComment(adminComment);
+        assertSame(obj.getName(), name);
+        assertEquals(obj.getAttributes(), 50L);
+        assertEquals(obj.getMemberCount(), 100L);
+        assertSame(obj.getAdminComment(), adminComment);
+    }
+
+    @Test
+    public void test_unmarshalPremable() throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(new byte[0]);
+        PacketInput in = new PacketInput(bin);
+        SAMPRGroupGeneralInformation obj = new SAMPRGroupGeneralInformation();
+        obj.unmarshalPreamble(in);
+        assertEquals(obj.getName(), new RPCUnicodeString.NonNullTerminated());
+        assertEquals(obj.getAttributes(), 0L);
+        assertEquals(obj.getMemberCount(), 0L);
+        assertEquals(obj.getAdminComment(), new RPCUnicodeString.NonNullTerminated());
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshalEntity() {
+        // Name: Non-Null, Attributes: 50, MemberCount: 4294967295 AdminComment: Non-Null
+        String hex1 = "1000100000000200 32000000 FFFFFFFF 1000100000000200";
+        SAMPRGroupGeneralInformation expect1 = new SAMPRGroupGeneralInformation();
+        expect1.setName(RPCUnicodeString.NonNullTerminated.of(""));
+        expect1.setAttributes(50L);
+        expect1.setMemberCount(4294967295L);
+        expect1.setAdminComment(RPCUnicodeString.NonNullTerminated.of(""));
+        // Name: Null, Attributes: 0, MemberCount: 0 AdminComment: Null
+        String hex2 = "0000000000000000 00000000 00000000 0000000000000000";
+        SAMPRGroupGeneralInformation expect2 = new SAMPRGroupGeneralInformation();
+        expect2.setName(RPCUnicodeString.NonNullTerminated.of(null));
+        expect2.setAttributes(0L);
+        expect2.setMemberCount(0L);
+        expect2.setAdminComment(RPCUnicodeString.NonNullTerminated.of(null));
+        // Alignment: 4b Name: Non-Null, Attributes: 50, MemberCount: 4294967295 AdminComment: Non-Null
+        String hex3 = "00000000" + hex1;
+        return new Object[][]{
+                {hex1, 0, expect1},
+                {hex2, 0, expect2},
+                // Alignment
+                {hex3, 1, expect1},
+                {hex3, 2, expect1},
+                {hex3, 3, expect1}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshalEntity")
+    public void test_unmarshalEntity(String hex, int mark, SAMPRGroupGeneralInformation expected) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        in.fullySkipBytes(mark);
+        SAMPRGroupGeneralInformation obj = new SAMPRGroupGeneralInformation();
+        obj.setName(new RPCUnicodeString.NonNullTerminated());
+        obj.setAdminComment(new RPCUnicodeString.NonNullTerminated());
+        obj.unmarshalEntity(in);
+        assertEquals(obj, expected);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshalDeferrals() {
+        String hex1 =
+                // UserName: testƟ121
+                "08000000000000000800000074006500730074009f01310032003100 " +
+                // FullName: testƟ122
+                "08000000000000000800000074006500730074009f01310032003200 ";
+        SAMPRGroupGeneralInformation obj1 = new SAMPRGroupGeneralInformation();
+        obj1.setName(RPCUnicodeString.NonNullTerminated.of(""));
+        obj1.setAttributes(50L);
+        obj1.setMemberCount(100L);
+        obj1.setAdminComment(RPCUnicodeString.NonNullTerminated.of(""));
+        SAMPRGroupGeneralInformation expected1 = new SAMPRGroupGeneralInformation();
+        expected1.setName(RPCUnicodeString.NonNullTerminated.of("testƟ121"));
+        expected1.setAttributes(50L);
+        expected1.setMemberCount(100L);
+        expected1.setAdminComment(RPCUnicodeString.NonNullTerminated.of("testƟ122"));
+        String hex2 = "";
+        SAMPRGroupGeneralInformation obj2 = new SAMPRGroupGeneralInformation();
+        obj2.setName(RPCUnicodeString.NonNullTerminated.of(null));
+        obj2.setAttributes(50L);
+        obj2.setMemberCount(100L);
+        obj2.setAdminComment(RPCUnicodeString.NonNullTerminated.of(null));
+        SAMPRGroupGeneralInformation expected2 = new SAMPRGroupGeneralInformation();
+        expected2.setName(RPCUnicodeString.NonNullTerminated.of(null));
+        expected2.setAttributes(50L);
+        expected2.setMemberCount(100L);
+        expected2.setAdminComment(RPCUnicodeString.NonNullTerminated.of(null));
+        String hex3 = "00000000" + hex1;
+        return new Object[][] {
+                {hex1, 0, obj1, expected1},
+                {hex2, 0, obj2, expected2},
+                // Alignment
+                {hex3, 1, obj1, expected1},
+                {hex3, 2, obj1, expected1},
+                {hex3, 3, obj1, expected1}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshalDeferrals")
+    public void test_unmarshalDeferrals(String hex, int mark,
+            SAMPRGroupGeneralInformation obj, SAMPRGroupGeneralInformation expected) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        in.fullySkipBytes(mark);
+        obj.unmarshalDeferrals(in);
+        assertEquals(obj, expected);
+    }
+
+    @Test
+    public void test_hashCode() {
+        SAMPRGroupGeneralInformation obj1 = new SAMPRGroupGeneralInformation();
+        SAMPRGroupGeneralInformation obj2 = new SAMPRGroupGeneralInformation();
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+        obj1.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
+        assertNotEquals(obj1.hashCode(), obj2.hashCode());
+        obj2.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+        obj1.setAttributes(50L);
+        assertNotEquals(obj1.hashCode(), obj2.hashCode());
+        obj2.setAttributes(50L);
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+        obj1.setMemberCount(100L);
+        assertNotEquals(obj1.hashCode(), obj2.hashCode());
+        obj2.setMemberCount(100L);
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+        obj1.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
+        assertNotEquals(obj1.hashCode(), obj2.hashCode());
+        obj2.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+    }
+
+    @Test
+    public void test_equals() {
+        SAMPRGroupGeneralInformation obj1 = new SAMPRGroupGeneralInformation();
+        SAMPRGroupGeneralInformation obj2 = new SAMPRGroupGeneralInformation();
+        assertEquals(obj1, obj2);
+        obj1.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
+        assertNotEquals(obj1, obj2);
+        obj2.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
+        assertEquals(obj1, obj2);
+        obj1.setAttributes(50L);
+        assertNotEquals(obj1, obj2);
+        obj2.setAttributes(50L);
+        assertEquals(obj1, obj2);
+        obj1.setMemberCount(100L);
+        assertNotEquals(obj1, obj2);
+        obj2.setMemberCount(100L);
+        assertEquals(obj1, obj2);
+        obj1.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
+        assertNotEquals(obj1, obj2);
+        obj2.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
+        assertEquals(obj1, obj2);
+    }
+
+    @Test
+    public void test_toString_defaults() {
+        assertEquals(new SAMPRGroupGeneralInformation().toString(), "SAMPR_GROUP_GENERAL_INFORMATION{Name:null,Attributes:0,MemberCount:0,AdminComment:null}");
+    }
+
+    @Test
+    public void test_toString() {
+        SAMPRGroupGeneralInformation obj = new SAMPRGroupGeneralInformation();
+        obj.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
+        obj.setAttributes(50L);
+        obj.setMemberCount(100L);
+        obj.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
+        assertEquals(obj.toString(), "SAMPR_GROUP_GENERAL_INFORMATION{Name:RPC_UNICODE_STRING{value:\"Name\", nullTerminated:false},Attributes:50,MemberCount:100,AdminComment:RPC_UNICODE_STRING{value:\"AdminComment\", nullTerminated:false}}");
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_UserInformationClass.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_UserInformationClass.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class Test_UserInformationClass {
+    @DataProvider
+    public Object[][] data_getInfoLevel() {
+        return new Object[][] {
+                {UserInformationClass.USER_ALL_INFORMATION, 21}
+        };
+    }
+
+    @Test(dataProvider = "data_getInfoLevel")
+    public void test_getInfoLevel(UserInformationClass obj, int expected) {
+        assertEquals(obj.getInfoLevel(), expected);
+    }
+}


### PR DESCRIPTION
- Adds SamrQueryInformationGroupRequest/Response with initial support for level 1 (SAMPR_GROUP_GENERAL_INFORMATION)
- Adds SAMPR_GROUP_GENERAL_INFORMATION
- Adds SecurityAccountManagerService.getGroupGeneralInformation
- Full unit test coverage where applicable