### PR TITLE
Adds SamrQuerySecurityObject

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
@@ -22,12 +22,18 @@ import static com.rapid7.client.dcerpc.mserref.SystemErrorCode.ERROR_MORE_ENTRIE
 import static com.rapid7.client.dcerpc.mserref.SystemErrorCode.ERROR_NO_MORE_ITEMS;
 import static com.rapid7.client.dcerpc.mserref.SystemErrorCode.ERROR_SUCCESS;
 import java.io.IOException;
+import java.rmi.UnmarshalException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import com.hierynomus.msdtyp.AccessMask;
 import com.hierynomus.msdtyp.SID;
+import com.hierynomus.msdtyp.SecurityDescriptor;
+import com.hierynomus.msdtyp.SecurityInformation;
+import com.hierynomus.protocol.commons.EnumWithValue;
+import com.hierynomus.protocol.commons.buffer.Buffer;
+import com.hierynomus.smb.SMBBuffer;
 import com.rapid7.client.dcerpc.RPCException;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrCloseHandleRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrCloseHandleResponse;
@@ -50,6 +56,7 @@ import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenUserResponse;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrQueryInformationAliasRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrQueryInformationGroupRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrQueryInformationUserRequest;
+import com.rapid7.client.dcerpc.mssamr.messages.SamrQuerySecurityObjectRequest;
 import com.rapid7.client.dcerpc.mssamr.objects.AliasHandle;
 import com.rapid7.client.dcerpc.mssamr.objects.AliasInfo;
 import com.rapid7.client.dcerpc.mssamr.objects.DomainHandle;
@@ -57,6 +64,7 @@ import com.rapid7.client.dcerpc.mssamr.objects.DomainInfo;
 import com.rapid7.client.dcerpc.mssamr.objects.GroupHandle;
 import com.rapid7.client.dcerpc.mssamr.objects.SAMPRAliasGeneralInformation;
 import com.rapid7.client.dcerpc.mssamr.objects.SAMPRGroupGeneralInformation;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRSRSecurityDescriptor;
 import com.rapid7.client.dcerpc.mssamr.objects.SAMPRUserAllInformation;
 import com.rapid7.client.dcerpc.mssamr.objects.GroupInfo;
 import com.rapid7.client.dcerpc.mssamr.objects.ServerHandle;
@@ -166,6 +174,13 @@ public class SecurityAccountManagerService {
         return transport.call(request).getAliasInformation();
     }
 
+    public SecurityDescriptor getSecurityDescriptor(final ContextHandle objectHandle, EnumSet<SecurityInformation> securityInformation) throws IOException {
+        SamrQuerySecurityObjectRequest request = new SamrQuerySecurityObjectRequest(
+                objectHandle, (int) EnumWithValue.EnumUtils.toLong(securityInformation));
+        SAMPRSRSecurityDescriptor securityDescriptor = transport.call(request).getSecurityDescriptor();
+        return null;
+    }
+
     /**
      * Gets the group names for the provided domain. Max buffer size will be used.
      *
@@ -235,6 +250,33 @@ public class SecurityAccountManagerService {
                 return transport.call(request);
             }
         });
+    }
+
+    public SecurityDescriptor getSecurityObject(final ContextHandle objectHandle,
+            final SecurityInformation ... securityInformation) throws IOException {
+        int securityInformationValue = 0;
+        if (securityInformation != null) {
+            for (SecurityInformation v : securityInformation) {
+                if (v == null)
+                    continue;
+                securityInformationValue |= v.getValue();
+            }
+        }
+        SamrQuerySecurityObjectRequest request = new SamrQuerySecurityObjectRequest(objectHandle, securityInformationValue);
+        return parseSecurityDescriptor(transport.call(request).getSecurityDescriptor());
+    }
+
+    public SecurityDescriptor parseSecurityDescriptor(SAMPRSRSecurityDescriptor securityDescriptor) throws IOException {
+        if (securityDescriptor == null)
+            return null;
+        byte[] payload = securityDescriptor.getSecurityDescriptor();
+        if (payload == null)
+            return null;
+        try {
+            return SecurityDescriptor.read(new SMBBuffer(payload));
+        } catch (Buffer.BufferException e) {
+            throw new UnmarshalException(String.format("Failed to parse %s", SAMPRSRSecurityDescriptor.class.getSimpleName()), e);
+        }
     }
 
     /**

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
@@ -47,6 +47,7 @@ import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenGroupRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenGroupResponse;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenUserRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenUserResponse;
+import com.rapid7.client.dcerpc.mssamr.messages.SamrQueryInformationAliasRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrQueryInformationGroupRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrQueryInformationUserRequest;
 import com.rapid7.client.dcerpc.mssamr.objects.AliasHandle;
@@ -54,6 +55,7 @@ import com.rapid7.client.dcerpc.mssamr.objects.AliasInfo;
 import com.rapid7.client.dcerpc.mssamr.objects.DomainHandle;
 import com.rapid7.client.dcerpc.mssamr.objects.DomainInfo;
 import com.rapid7.client.dcerpc.mssamr.objects.GroupHandle;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRAliasGeneralInformation;
 import com.rapid7.client.dcerpc.mssamr.objects.SAMPRGroupGeneralInformation;
 import com.rapid7.client.dcerpc.mssamr.objects.SAMPRUserAllInformation;
 import com.rapid7.client.dcerpc.mssamr.objects.GroupInfo;
@@ -157,6 +159,11 @@ public class SecurityAccountManagerService {
     public SAMPRGroupGeneralInformation getGroupGeneralInformation(final GroupHandle groupHandle) throws IOException {
         SamrQueryInformationGroupRequest.GroupGeneralInformation request = new SamrQueryInformationGroupRequest.GroupGeneralInformation(groupHandle);
         return transport.call(request).getGroupInformation();
+    }
+
+    public SAMPRAliasGeneralInformation getAliasGeneralInformation(final AliasHandle aliasHandle) throws IOException {
+        SamrQueryInformationAliasRequest.AliasGeneralInformation request = new SamrQueryInformationAliasRequest.AliasGeneralInformation(aliasHandle);
+        return transport.call(request).getAliasInformation();
     }
 
     /**

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationAliasRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationAliasRequest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+import com.rapid7.client.dcerpc.messages.RequestCall;
+import com.rapid7.client.dcerpc.mssamr.objects.AliasHandle;
+import com.rapid7.client.dcerpc.mssamr.objects.AliasInformationClass;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRAliasGeneralInformation;
+
+/**
+ * <a href="https://msdn.microsoft.com/en-us/library/cc245782.aspx">SamrQueryInformationAlias</a>
+ *
+ * <blockquote><pre>The SamrQueryInformationAlias method obtains attributes from an alias object.
+ *      long SamrQueryInformationAlias(
+ *          [in] SAMPR_HANDLE AliasHandle,
+ *          [in] ALIAS_INFORMATION_CLASS AliasInformationClass,
+ *          [out, switch_is(AliasInformationClass)]
+ *          PSAMPR_ALIAS_INFO_BUFFER* Buffer
+ *      );
+ *  AliasHandle: An RPC context handle, as specified in section 2.2.3.2, representing an alias object.
+ *  AliasInformationClass: An enumeration indicating which attributes to return. See section 2.2.6.5 for a listing of possible values.
+ *  Buffer: The requested attributes on output. See section 2.2.6.6 for structure details.
+ *
+ *  This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject the use of context handles created by a method of a different RPC interface than this one, as specified in [MS-RPCE] section 3.
+ *
+ *  Upon receiving this message, the server MUST process the data from the message subject to the following constraints:
+ *      1. The server MUST return an error if AliasHandle.HandleType is not equal to "Alias".
+ *      2. AliasHandle.GrantedAccess MUST have the required access specified in section 3.1.2.1. Otherwise, the server MUST return STATUS_ACCESS_DENIED.
+ *      3. The following information levels MUST be processed by setting the appropriate output field name to the associated database attribute, as specified in section 3.1.5.14.10. Processing is completed by returning 0 on success. If the presented information level is not in the following table, the server MUST return an error.</pre></blockquote>
+ */
+public abstract class SamrQueryInformationAliasRequest<T extends Unmarshallable> extends RequestCall<SamrQueryInformationAliasResponse<T>> {
+    public static final short OP_NUM = 28;
+
+    private final AliasHandle aliasHandle;
+
+    SamrQueryInformationAliasRequest(AliasHandle aliasHandle) {
+        super(OP_NUM);
+        this.aliasHandle = aliasHandle;
+    }
+
+    public AliasHandle getAliasHandle() {
+        return aliasHandle;
+    }
+
+    public abstract AliasInformationClass getAliasInformationClass();
+
+    @Override
+    public void marshal(PacketOutput packetOut) throws IOException {
+        // <NDR: struct> [in] SAMPR_HANDLE AliasHandle,
+        packetOut.writeMarshallable(getAliasHandle());
+        // <NDR: unsigned short> [in] ALIAS_INFORMATION_CLASS AliasInformationClass,
+        // Alignment: 2 - Already aligned. ContextHandle writes 20 bytes above
+        packetOut.writeShort(getAliasInformationClass().getInfoLevel());
+    }
+
+    public static class AliasGeneralInformation extends SamrQueryInformationAliasRequest<SAMPRAliasGeneralInformation> {
+        public AliasGeneralInformation(AliasHandle aliasHandle) {
+            super(aliasHandle);
+        }
+
+        @Override
+        public AliasInformationClass getAliasInformationClass() {
+            return AliasInformationClass.ALIAS_GENERALINFORMATION;
+        }
+
+        @Override
+        public SamrQueryInformationAliasResponse.AliasGeneralInformation getResponseObject() {
+            return new SamrQueryInformationAliasResponse.AliasGeneralInformation();
+        }
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationAliasResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationAliasResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import java.rmi.UnmarshalException;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+import com.rapid7.client.dcerpc.messages.RequestResponse;
+import com.rapid7.client.dcerpc.mssamr.objects.AliasInformationClass;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRAliasGeneralInformation;
+
+public abstract class SamrQueryInformationAliasResponse<T extends Unmarshallable> extends RequestResponse {
+    private T aliasInformation;
+
+    public T getAliasInformation() {
+        return aliasInformation;
+    }
+
+    public abstract AliasInformationClass getAliasInformationClass();
+
+    abstract T createAliasInformation();
+
+    @Override
+    public void unmarshal(PacketInput packetIn) throws IOException {
+        if(packetIn.readReferentID() != 0) {
+            final int infoLevel = packetIn.readUnsignedShort();
+            if (infoLevel != getAliasInformationClass().getInfoLevel()) {
+                throw new UnmarshalException(String.format(
+                        "Incoming ALIAS_INFORMATION_CLASS %d does not match expected: %d",
+                        infoLevel, getAliasInformationClass().getInfoLevel()));
+            }
+            this.aliasInformation = createAliasInformation();
+            packetIn.readUnmarshallable(this.aliasInformation);
+        } else {
+            this.aliasInformation = null;
+        }
+    }
+
+    public static class AliasGeneralInformation extends SamrQueryInformationAliasResponse<SAMPRAliasGeneralInformation> {
+        @Override
+        public AliasInformationClass getAliasInformationClass() {
+            return AliasInformationClass.ALIAS_GENERALINFORMATION;
+        }
+
+        @Override
+        SAMPRAliasGeneralInformation createAliasInformation() {
+            return new SAMPRAliasGeneralInformation();
+        }
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQuerySecurityObjectRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQuerySecurityObjectRequest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.messages.RequestCall;
+import com.rapid7.client.dcerpc.objects.ContextHandle;
+
+/**
+ * <a href="https://msdn.microsoft.com/en-us/library/cc245718.aspx">SamrQuerySecurityObject</a>
+ * <blockquote><pre>The SamrQuerySecurityObject method queries the access control on a server, domain, user, group, or alias object.
+ *      long SamrQuerySecurityObject(
+ *          [in] SAMPR_HANDLE ObjectHandle,
+ *          [in] SECURITY_INFORMATION SecurityInformation,
+ *          [out] PSAMPR_SR_SECURITY_DESCRIPTOR* SecurityDescriptor
+ *      );
+ *  ObjectHandle: An RPC context handle, as specified in section 2.2.3.2, representing a server, domain, user, group, or alias object.
+ *  SecurityInformation: A bit field that specifies which fields of SecurityDescriptor the client is requesting to be returned.
+ *      The SECURITY_INFORMATION type is defined in [MS-DTYP] section 2.4.7. The following bits are valid; all other bits MUST be zero when sent and ignored on receipt.
+ *
+ *      OWNER_SECURITY_INFORMATION          If this bit is set, the client requests that the Owner member be returned.
+ *      0x00000001                          If this bit is not set, the client requests that the Owner member not be returned.
+ *
+ *      GROUP_SECURITY_INFORMATION          If this bit is set, the client requests that the Group member be returned.
+ *      0x00000002                          If this bit is not set, the client requests that the Group member not be returned.
+ *
+ *      DACL_SECURITY_INFORMATION           If this bit is set, the client requests that the DACL be returned.
+ *      0x00000004                          If this bit is not set, the client requests that the DACL not be returned.
+ *
+ *      SACL_SECURITY_INFORMATION           If this bit is set, the client requests that the SACL be returned.
+ *      0x00000008                          If this bit is not set, the client requests that the SACL not be returned.
+ *
+ *  SecurityDescriptor: A security descriptor expressing accesses that are specific to the ObjectHandle and the owner and group of the object. [MS-DTYP] section 2.4.6 contains the specification for a valid security descriptor.
+ *
+ *  This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject the use of context handles created by a method of a different RPC interface than this one, as specified in [MS-RPCE] section 3.</pre></blockquote>
+ */
+public class SamrQuerySecurityObjectRequest extends RequestCall<SamrQuerySecurityObjectResponse> {
+    public static final short OP_NUM = 3;
+
+    // <NDR: struct> [in] SAMPR_HANDLE ObjectHandle,
+    private final ContextHandle objectHandle;
+    // <NDR: unsigned long> [in] SECURITY_INFORMATION SecurityInformation,
+    // This is a bitmask, so can store as an int
+    private final int securityInformation;
+
+    public SamrQuerySecurityObjectRequest(final ContextHandle objectHandle, final int securityInformation) {
+        super(OP_NUM);
+        this.objectHandle = objectHandle;
+        this.securityInformation = securityInformation;
+    }
+
+    public ContextHandle getObjectHandle() {
+        return objectHandle;
+    }
+
+    public int getSecurityInformation() {
+        return securityInformation;
+    }
+
+
+    @Override
+    public SamrQuerySecurityObjectResponse getResponseObject() {
+        return new SamrQuerySecurityObjectResponse();
+    }
+
+    @Override
+    public void marshal(PacketOutput packetOut) throws IOException {
+        // <NDR: struct> [in] SAMPR_HANDLE ObjectHandle,
+        packetOut.writeMarshallable(getObjectHandle());
+        // <NDR: unsigned long> [in] SECURITY_INFORMATION SecurityInformation,
+        // Alignment: 4 - Already aligned, we wrote 20 bytes above
+        packetOut.writeInt(getSecurityInformation());
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQuerySecurityObjectResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQuerySecurityObjectResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.messages.RequestResponse;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRSRSecurityDescriptor;
+
+public class SamrQuerySecurityObjectResponse extends RequestResponse {
+
+    // <NDR: struct>[out] PSAMPR_SR_SECURITY_DESCRIPTOR* SecurityDescriptor
+    private SAMPRSRSecurityDescriptor securityDescriptor;
+
+    public SAMPRSRSecurityDescriptor getSecurityDescriptor() {
+        return securityDescriptor;
+    }
+
+    @Override
+    public void unmarshal(PacketInput packetIn) throws IOException {
+        if (packetIn.readReferentID() != 0) {
+            this.securityDescriptor = new SAMPRSRSecurityDescriptor();
+            packetIn.readUnmarshallable(this.securityDescriptor);
+        } else {
+            this.securityDescriptor = null;
+        }
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/AliasInformationClass.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/AliasInformationClass.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+/** *
+ * <b>Alignment: 2</b>
+ * <br>
+ * <a href="https://msdn.microsoft.com/en-us/library/cc245593.aspx">ALIAS_INFORMATION_CLASS</a>
+ * <blockquote><pre>The ALIAS_INFORMATION_CLASS enumeration indicates how to interpret the Buffer parameter for SamrQueryInformationAlias and SamrSetInformationAlias. For a list of the structures associated with each enumeration, see section 2.2.6.6.
+ *      typedef  enum _ALIAS_INFORMATION_CLASS
+ *      {
+ *          AliasGeneralInformation = 1,
+ *          AliasNameInformation,
+ *          AliasAdminCommentInformation
+ *      } ALIAS_INFORMATION_CLASS;
+ *  AliasGeneralInformation:  Indicates the Buffer parameter is to be interpreted as a SAMPR_ALIAS_GENERAL_INFORMATION structure (see section 2.2.6.2).
+ *  AliasNameInformation:  Indicates the Buffer parameter is to be interpreted as a SAMPR_ALIAS_NAME_INFORMATION structure (see section 2.2.6.3).
+ *  AliasAdminCommentInformation:  Indicates the Buffer parameter is to be interpreted as a SAMPR_ALIAS_ADM_COMMENT_INFORMATION structure (see section 2.2.6.4).</pre></blockquote>
+ */
+public enum AliasInformationClass {
+    ALIAS_GENERALINFORMATION(1);
+
+    private final int infoLevel;
+
+    AliasInformationClass(final int infoLevel) {
+        this.infoLevel = infoLevel;
+    }
+
+    public int getInfoLevel() {
+        return infoLevel;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ALIAS_INFORMATION_CLASS{name:%s, infoLevel:%d}", name(), getInfoLevel());
+    }
+
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRAliasGeneralInformation.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRAliasGeneralInformation.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+import java.io.IOException;
+import java.util.Objects;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
+
+/**
+ * <b>Alignment: 4</b><pre>
+ *     RPC_UNICODE_STRING Name;: 4
+ *     unsigned long MemberCount;: 4
+ *     RPC_UNICODE_STRING AdminComment;: 4</pre>
+ * <a href="https://msdn.microsoft.com/en-us/library/cc245590.aspx">SAMPR_ALIAS_GENERAL_INFORMATION</a>
+ * <blockquote><pre>The SAMPR_ALIAS_GENERAL_INFORMATION structure contains alias fields.
+ *      typedef struct _SAMPR_ALIAS_GENERAL_INFORMATION {
+ *          RPC_UNICODE_STRING Name;
+ *          unsigned long MemberCount;
+ *          RPC_UNICODE_STRING AdminComment;
+ *      } SAMPR_ALIAS_GENERAL_INFORMATION,
+ *      *PSAMPR_ALIAS_GENERAL_INFORMATION;
+ *  For information on each field, see section 2.2.6.1.</pre></blockquote>
+ */
+public class SAMPRAliasGeneralInformation implements Unmarshallable {
+    // <NDR: struct> RPC_UNICODE_STRING Name;
+    private RPCUnicodeString.NonNullTerminated name;
+    // <NDR: unsigned long> unsigned long MemberCount;
+    private long memberCount;
+    // <NDR: struct> RPC_UNICODE_STRING AdminComment;
+    private RPCUnicodeString.NonNullTerminated adminComment;
+
+    public RPCUnicodeString.NonNullTerminated getName() {
+        return name;
+    }
+
+    public void setName(RPCUnicodeString.NonNullTerminated name) {
+        this.name = name;
+    }
+
+    public long getMemberCount() {
+        return memberCount;
+    }
+
+    public void setMemberCount(long memberCount) {
+        this.memberCount = memberCount;
+    }
+
+    public RPCUnicodeString.NonNullTerminated getAdminComment() {
+        return adminComment;
+    }
+
+    public void setAdminComment(RPCUnicodeString.NonNullTerminated adminComment) {
+        this.adminComment = adminComment;
+    }
+
+    @Override
+    public void unmarshalPreamble(PacketInput in) throws IOException {
+        // <NDR: struct> RPC_UNICODE_STRING Name;
+        name = new RPCUnicodeString.NonNullTerminated();
+        name.unmarshalPreamble(in);
+        // <NDR: struct> RPC_UNICODE_STRING AdminComment;
+        adminComment = new RPCUnicodeString.NonNullTerminated();
+        adminComment.unmarshalPreamble(in);
+    }
+
+    @Override
+    public void unmarshalEntity(PacketInput in) throws IOException {
+        // Structure Alignment: 4
+        in.align(Alignment.FOUR);
+        // <NDR: struct> RPC_UNICODE_STRING Name;
+        name.unmarshalEntity(in);
+        // <NDR: unsigned long> unsigned long MemberCount;
+        in.align(Alignment.FOUR);
+        memberCount = in.readUnsignedInt();
+        // <NDR: struct> RPC_UNICODE_STRING AdminComment;
+        adminComment.unmarshalEntity(in);
+    }
+
+    @Override
+    public void unmarshalDeferrals(PacketInput in) throws IOException {
+        // <NDR: struct> RPC_UNICODE_STRING Name;
+        name.unmarshalDeferrals(in);
+        // <NDR: struct> RPC_UNICODE_STRING AdminComment;
+        adminComment.unmarshalDeferrals(in);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getMemberCount(), getAdminComment());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (! (obj instanceof SAMPRAliasGeneralInformation)) {
+            return false;
+        }
+        SAMPRAliasGeneralInformation other = (SAMPRAliasGeneralInformation) obj;
+        return Objects.equals(getName(), other.getName())
+                && Objects.equals(getMemberCount(), other.getMemberCount())
+                && Objects.equals(getAdminComment(), other.getAdminComment());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("SAMPR_ALIAS_GENERAL_INFORMATION{Name:%s,MemberCount:%d,AdminComment:%s}",
+                getName(), getMemberCount(), getAdminComment());
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRSRSecurityDescriptor.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRSRSecurityDescriptor.java
@@ -44,13 +44,14 @@ import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
  */
 public class SAMPRSRSecurityDescriptor implements Unmarshallable {
     // [size_is(Length)] unsigned char* SecurityDescriptor;
-    private char[] securityDescriptor;
+    // Despite being an unsigned char (char[]), store as byte[] for parsing convenience
+    private byte[] securityDescriptor;
 
-    public char[] getSecurityDescriptor() {
+    public byte[] getSecurityDescriptor() {
         return securityDescriptor;
     }
 
-    public void setSecurityDescriptor(char[] securityDescriptor) {
+    public void setSecurityDescriptor(byte[] securityDescriptor) {
         this.securityDescriptor = securityDescriptor;
     }
 
@@ -70,7 +71,7 @@ public class SAMPRSRSecurityDescriptor implements Unmarshallable {
         // Alignment: 4 - Already aligned
         if (in.readReferentID() != 0) {
             if (length > 0)
-                securityDescriptor = new char[length];
+                securityDescriptor = new byte[length];
         } else {
             securityDescriptor = null;
         }
@@ -86,7 +87,7 @@ public class SAMPRSRSecurityDescriptor implements Unmarshallable {
             for (int i = 0; i < securityDescriptor.length; i++) {
                 // <NDR: unsigned char>
                 // Alignment: 1 - Already aligned
-                securityDescriptor[i] = in.readUnsignedByte();
+                securityDescriptor[i] = in.readByte();
             }
         }
     }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/Test_SecurityAccountManagerService.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/Test_SecurityAccountManagerService.java
@@ -19,15 +19,22 @@
 package com.rapid7.client.dcerpc.mssamr;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 import org.mockito.Mockito;
+import com.hierynomus.msdtyp.SID;
+import com.hierynomus.msdtyp.SecurityDescriptor;
 import com.rapid7.client.dcerpc.mserref.SystemErrorCode;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrEnumerateDomainsInSamServerRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrEnumerateDomainsInSamServerResponse;
 import com.rapid7.client.dcerpc.mssamr.objects.DomainInfo;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRSRSecurityDescriptor;
 import com.rapid7.client.dcerpc.mssamr.objects.ServerHandle;
 import com.rapid7.client.dcerpc.transport.RPCTransport;
 
@@ -68,5 +75,34 @@ public class Test_SecurityAccountManagerService {
         Mockito.when(transport.call(Mockito.any(SamrEnumerateDomainsInSamServerRequest.class))).thenReturn(response1)
             .thenReturn(response2);
         assertEquals(2, service.getDomainsForServer(handle).size());
+    }
+
+    @Test
+    public void test_parseSecurityDescriptor() throws IOException {
+        String hex = "01000080140000002400000000000000000000000102000000000005200000002002000001020000000000052000000020020000";
+
+        RPCTransport transport = Mockito.mock(RPCTransport.class);
+        SecurityAccountManagerService service = new SecurityAccountManagerService(transport);
+        SAMPRSRSecurityDescriptor samprsrSecurityDescriptor = new SAMPRSRSecurityDescriptor();
+        samprsrSecurityDescriptor.setSecurityDescriptor(Hex.decode(hex));
+
+        SecurityDescriptor securityDescriptor = service.parseSecurityDescriptor(samprsrSecurityDescriptor);
+        assertEquals(Collections.singleton(SecurityDescriptor.Control.SR), securityDescriptor.getControl());
+        assertEquals(SID.fromString("S-1-5-32-544"), securityDescriptor.getOwnerSid());
+        assertEquals(SID.fromString("S-1-5-32-544"), securityDescriptor.getGroupSid());
+    }
+
+    @Test
+    public void test_parseSecurityDescriptor_nullSAMPRSRSecurityDescriptor() throws IOException {
+        RPCTransport transport = Mockito.mock(RPCTransport.class);
+        SecurityAccountManagerService service = new SecurityAccountManagerService(transport);
+        assertNull(service.parseSecurityDescriptor(null));
+    }
+
+    @Test
+    public void test_parseSecurityDescriptor_nullPayload() throws IOException {
+        RPCTransport transport = Mockito.mock(RPCTransport.class);
+        SecurityAccountManagerService service = new SecurityAccountManagerService(transport);
+        assertNull(service.parseSecurityDescriptor(new SAMPRSRSecurityDescriptor()));
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationAliasRequest.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationAliasRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.mssamr.objects.AliasHandle;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class Test_SamrQueryInformationAliasRequest {
+
+    @DataProvider
+    public Object[][] data_requests() {
+        AliasHandle handle = new AliasHandle();
+        handle.setBytes(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20});
+        return new Object[][] {
+                {new SamrQueryInformationAliasRequest.AliasGeneralInformation(handle)}
+        };
+    }
+
+    @Test(dataProvider = "data_requests")
+    public void test_getOpNum(SamrQueryInformationAliasRequest request) {
+        assertEquals(request.getOpNum(), SamrQueryInformationAliasRequest.OP_NUM);
+    }
+
+    @Test(dataProvider = "data_requests")
+    public void test_getResponseObject(SamrQueryInformationAliasRequest request) {
+        assertNotNull(request.getResponseObject());
+    }
+
+    @Test(dataProvider = "data_requests")
+    public void test_marshall(SamrQueryInformationAliasRequest request) throws IOException {
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        PacketOutput out = new PacketOutput(bout);
+        request.marshal(out);
+
+        ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
+        PacketInput in = new PacketInput(bin);
+        assertEquals(in.readRawBytes(20), request.getAliasHandle().getBytes());
+        assertEquals(in.readUnsignedShort(), request.getAliasInformationClass().getInfoLevel());
+        assertEquals(bin.available(), 0);
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationAliasResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationAliasResponse.java
@@ -29,8 +29,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import com.rapid7.client.dcerpc.io.PacketInput;
 import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
-import com.rapid7.client.dcerpc.mssamr.objects.GroupInformationClass;
-import com.rapid7.client.dcerpc.mssamr.objects.UserInformationClass;
+import com.rapid7.client.dcerpc.mssamr.objects.AliasInformationClass;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -39,65 +38,65 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 
-public class Test_SamrQueryInformationGroupResponse {
+public class Test_SamrQueryInformationAliasResponse {
 
     @DataProvider
     public Object[][] data_getters() {
         return new Object[][] {
-                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), GroupInformationClass.GROUP_GENERAL_INFORMATION}
+                {new SamrQueryInformationAliasResponse.AliasGeneralInformation(), AliasInformationClass.ALIAS_GENERALINFORMATION}
         };
     }
 
     @Test(dataProvider = "data_getters")
-    public void test_getters(SamrQueryInformationGroupResponse response, GroupInformationClass expectedGroupInformationClass) {
-        assertNull(response.getGroupInformation());
-        assertSame(response.getGroupInformationClass(), expectedGroupInformationClass);
+    public void test_getters(SamrQueryInformationAliasResponse response, AliasInformationClass expectedAliasInformationClass) {
+        assertNull(response.getAliasInformation());
+        assertSame(response.getAliasInformationClass(), expectedAliasInformationClass);
     }
 
     @DataProvider
     public Object[][] data_unmarshal() {
         return new Object[][] {
-                // Reference: 1, GROUP_INFORMATION_CLASS: 1
-                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "01000000 0100"}
+                // Reference: 1, ALIAS_INFORMATION_CLASS: 1
+                {new SamrQueryInformationAliasResponse.AliasGeneralInformation(), "01000000 0100"}
         };
     }
 
     @Test(dataProvider = "data_unmarshal")
-    public void test_unmarshal(SamrQueryInformationGroupResponse response, String hex) throws IOException {
+    public void test_unmarshal(SamrQueryInformationAliasResponse response, String hex) throws IOException {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = spy(new PacketInput(bin));
         doReturn(null).when(in).readUnmarshallable(any(Unmarshallable.class));
         response.unmarshal(in);
-        assertNotNull(response.getGroupInformation());
+        assertNotNull(response.getAliasInformation());
     }
 
     @DataProvider
     public Object[][] data_unmarshall_Null() {
         return new Object[][] {
-                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "00000000 0100"}
+                {new SamrQueryInformationAliasResponse.AliasGeneralInformation(), "00000000 0100"}
         };
     }
 
     @Test(dataProvider = "data_unmarshall_Null")
-    public void test_unmarshall_Null(SamrQueryInformationGroupResponse response, String hex) throws IOException {
+    public void test_unmarshall_Null(SamrQueryInformationAliasResponse response, String hex) throws IOException {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = spy(new PacketInput(bin));
         response.unmarshal(in);
-        assertNull(response.getGroupInformation());
+        assertNull(response.getAliasInformation());
     }
 
     @DataProvider
     public Object[][] data_unmarshal_InvalidTag() {
         return new Object[][] {
                 // Reference: 1, POLICY_CLASS_INFORMATION: 3
-                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "01000000 FFFF"},
+                {new SamrQueryInformationAliasResponse.AliasGeneralInformation(), "01000000 FFFF"},
         };
     }
 
     @Test(dataProvider = "data_unmarshal_InvalidTag",
             expectedExceptions = {UnmarshalException.class},
-            expectedExceptionsMessageRegExp = "Incoming GROUP_INFORMATION_CLASS 65535 does not match expected: [0-9]+")
-    public void test_unmarshal_InvalidTag(SamrQueryInformationGroupResponse response, String hex) throws IOException {
+            expectedExceptionsMessageRegExp = "Incoming ALIAS_INFORMATION_CLASS 65535 does not match expected: [0-9]+")
+    public void test_unmarshal_InvalidTag(SamrQueryInformationAliasResponse response, String hex) throws IOException {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = spy(new PacketInput(bin));
         response.unmarshal(in);

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQuerySecurityObjectRequest.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQuerySecurityObjectRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.Test;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.objects.ContextHandle;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+
+public class Test_SamrQuerySecurityObjectRequest {
+    @Test
+    public void test_getters() {
+        ContextHandle objectHandle = new ContextHandle();
+        int securityInformation = 50;
+        SamrQuerySecurityObjectRequest request = new SamrQuerySecurityObjectRequest(objectHandle, securityInformation);
+        assertSame(request.getObjectHandle(), objectHandle);
+        assertEquals(request.getSecurityInformation(), 50);
+        assertNotNull(request.getResponseObject());
+    }
+
+    @Test
+    public void test_marshall() throws IOException {
+        String expectHex =
+                // ContextHandle: {1, 2, 3, 4, ...}
+                "0102030405060708090A0B0C0E0F101112131415" +
+                // SecurityInformation: 50
+                "32000000";
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        PacketOutput out = new PacketOutput(bout);
+
+        ContextHandle objectHandle = new ContextHandle();
+        objectHandle.setBytes(Hex.decode("0102030405060708090A0B0C0E0F101112131415"));
+        int securityInformation = 50;
+        SamrQuerySecurityObjectRequest request = new SamrQuerySecurityObjectRequest(objectHandle, securityInformation);
+        request.marshal(out);
+
+        assertEquals(Hex.toHexString(bout.toByteArray()), expectHex.toLowerCase());
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQuerySecurityObjectResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQuerySecurityObjectResponse.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.Test;
+
+import com.rapid7.client.dcerpc.io.PacketInput;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+public class Test_SamrQuerySecurityObjectResponse {
+    @Test
+    public void test_getters_default() {
+        SamrQuerySecurityObjectResponse response = new SamrQuerySecurityObjectResponse();
+        assertNull(response.getSecurityDescriptor());
+    }
+
+    @Test
+    public void test_unmarshal() throws IOException {
+
+        String hex =
+                // Reference: 2
+                "02000000" +
+                // SecurityDescriptor: Length: 2 Reference: 2
+                "02000000 00000200" +
+                // SecurityDescriptor: MaximumCount: 3 SecurityDescriptor: {1, 2}
+                "02000000 01 02";
+
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+
+        SamrQuerySecurityObjectResponse response = new SamrQuerySecurityObjectResponse();
+        response.unmarshal(in);
+
+        assertNotNull(response.getSecurityDescriptor());
+        assertEquals(response.getSecurityDescriptor().getSecurityDescriptor(), new byte[]{1, 2});
+    }
+
+    @Test
+    public void test_unmarshal_null() throws IOException {
+        // Reference: 0
+        String hex = "00000000";
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+
+        SamrQuerySecurityObjectResponse response = new SamrQuerySecurityObjectResponse();
+        response.unmarshal(in);
+
+        assertNull(response.getSecurityDescriptor());
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_AliasInformationClass.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_AliasInformationClass.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class Test_AliasInformationClass {
+    @DataProvider
+    public Object[][] data_getInfoLevel() {
+        return new Object[][] {
+                {AliasInformationClass.ALIAS_GENERALINFORMATION, 1}
+        };
+    }
+
+    @Test(dataProvider = "data_getInfoLevel")
+    public void test_getInfoLevel(AliasInformationClass obj, int expected) {
+        assertEquals(obj.getInfoLevel(), expected);
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRAliasGeneralInformation.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRAliasGeneralInformation.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+public class Test_SAMPRAliasGeneralInformation {
+
+    @Test
+    public void test_getters() {
+        SAMPRAliasGeneralInformation obj = new SAMPRAliasGeneralInformation();
+        assertNull(obj.getName());
+        assertEquals(obj.getMemberCount(), 0L);
+        assertNull(obj.getAdminComment());
+    }
+
+    @Test
+    public void test_setters() {
+        SAMPRAliasGeneralInformation obj = new SAMPRAliasGeneralInformation();
+        RPCUnicodeString.NonNullTerminated name = RPCUnicodeString.NonNullTerminated.of("Name");
+        obj.setName(name);
+        obj.setMemberCount(100L);
+        RPCUnicodeString.NonNullTerminated adminComment = RPCUnicodeString.NonNullTerminated.of("AdminComment");
+        obj.setAdminComment(adminComment);
+        assertSame(obj.getName(), name);
+        assertEquals(obj.getMemberCount(), 100L);
+        assertSame(obj.getAdminComment(), adminComment);
+    }
+
+    @Test
+    public void test_unmarshalPremable() throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(new byte[0]);
+        PacketInput in = new PacketInput(bin);
+        SAMPRAliasGeneralInformation obj = new SAMPRAliasGeneralInformation();
+        obj.unmarshalPreamble(in);
+        assertEquals(obj.getName(), new RPCUnicodeString.NonNullTerminated());
+        assertEquals(obj.getMemberCount(), 0L);
+        assertEquals(obj.getAdminComment(), new RPCUnicodeString.NonNullTerminated());
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshalEntity() {
+        // Name: Non-Null, MemberCount: 4294967295 AdminComment: Non-Null
+        String hex1 = "1000100000000200 FFFFFFFF 1000100000000200";
+        SAMPRAliasGeneralInformation expect1 = new SAMPRAliasGeneralInformation();
+        expect1.setName(RPCUnicodeString.NonNullTerminated.of(""));
+        expect1.setMemberCount(4294967295L);
+        expect1.setAdminComment(RPCUnicodeString.NonNullTerminated.of(""));
+        // Name: Null, MemberCount: 0 AdminComment: Null
+        String hex2 = "0000000000000000 00000000 0000000000000000";
+        SAMPRAliasGeneralInformation expect2 = new SAMPRAliasGeneralInformation();
+        expect2.setName(RPCUnicodeString.NonNullTerminated.of(null));
+        expect2.setMemberCount(0L);
+        expect2.setAdminComment(RPCUnicodeString.NonNullTerminated.of(null));
+        // Alignment: 4b Name: Non-Null, MemberCount: 4294967295 AdminComment: Non-Null
+        String hex3 = "00000000" + hex1;
+        return new Object[][]{
+                {hex1, 0, expect1},
+                {hex2, 0, expect2},
+                // Alignment
+                {hex3, 1, expect1},
+                {hex3, 2, expect1},
+                {hex3, 3, expect1}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshalEntity")
+    public void test_unmarshalEntity(String hex, int mark, SAMPRAliasGeneralInformation expected) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        in.fullySkipBytes(mark);
+        SAMPRAliasGeneralInformation obj = new SAMPRAliasGeneralInformation();
+        obj.setName(new RPCUnicodeString.NonNullTerminated());
+        obj.setAdminComment(new RPCUnicodeString.NonNullTerminated());
+        obj.unmarshalEntity(in);
+        assertEquals(obj, expected);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshalDeferrals() {
+        String hex1 =
+                // UserName: testƟ121
+                "08000000000000000800000074006500730074009f01310032003100 " +
+                // FullName: testƟ122
+                "08000000000000000800000074006500730074009f01310032003200 ";
+        SAMPRAliasGeneralInformation obj1 = new SAMPRAliasGeneralInformation();
+        obj1.setName(RPCUnicodeString.NonNullTerminated.of(""));
+        obj1.setMemberCount(100L);
+        obj1.setAdminComment(RPCUnicodeString.NonNullTerminated.of(""));
+        SAMPRAliasGeneralInformation expected1 = new SAMPRAliasGeneralInformation();
+        expected1.setName(RPCUnicodeString.NonNullTerminated.of("testƟ121"));
+        expected1.setMemberCount(100L);
+        expected1.setAdminComment(RPCUnicodeString.NonNullTerminated.of("testƟ122"));
+        String hex2 = "";
+        SAMPRAliasGeneralInformation obj2 = new SAMPRAliasGeneralInformation();
+        obj2.setName(RPCUnicodeString.NonNullTerminated.of(null));
+        obj2.setMemberCount(100L);
+        obj2.setAdminComment(RPCUnicodeString.NonNullTerminated.of(null));
+        SAMPRAliasGeneralInformation expected2 = new SAMPRAliasGeneralInformation();
+        expected2.setName(RPCUnicodeString.NonNullTerminated.of(null));
+        expected2.setMemberCount(100L);
+        expected2.setAdminComment(RPCUnicodeString.NonNullTerminated.of(null));
+        String hex3 = "00000000" + hex1;
+        return new Object[][] {
+                {hex1, 0, obj1, expected1},
+                {hex2, 0, obj2, expected2},
+                // Alignment
+                {hex3, 1, obj1, expected1},
+                {hex3, 2, obj1, expected1},
+                {hex3, 3, obj1, expected1}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshalDeferrals")
+    public void test_unmarshalDeferrals(String hex, int mark,
+            SAMPRAliasGeneralInformation obj, SAMPRAliasGeneralInformation expected) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        in.fullySkipBytes(mark);
+        obj.unmarshalDeferrals(in);
+        assertEquals(obj, expected);
+    }
+
+    @Test
+    public void test_hashCode() {
+        SAMPRAliasGeneralInformation obj1 = new SAMPRAliasGeneralInformation();
+        SAMPRAliasGeneralInformation obj2 = new SAMPRAliasGeneralInformation();
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+        obj1.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
+        assertNotEquals(obj1.hashCode(), obj2.hashCode());
+        obj2.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+        obj1.setMemberCount(100L);
+        assertNotEquals(obj1.hashCode(), obj2.hashCode());
+        obj2.setMemberCount(100L);
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+        obj1.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
+        assertNotEquals(obj1.hashCode(), obj2.hashCode());
+        obj2.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+    }
+
+    @Test
+    public void test_equals() {
+        SAMPRAliasGeneralInformation obj1 = new SAMPRAliasGeneralInformation();
+        SAMPRAliasGeneralInformation obj2 = new SAMPRAliasGeneralInformation();
+        assertEquals(obj1, obj2);
+        obj1.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
+        assertNotEquals(obj1, obj2);
+        obj2.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
+        assertEquals(obj1, obj2);
+        obj1.setMemberCount(100L);
+        assertNotEquals(obj1, obj2);
+        obj2.setMemberCount(100L);
+        assertEquals(obj1, obj2);
+        obj1.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
+        assertNotEquals(obj1, obj2);
+        obj2.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
+        assertEquals(obj1, obj2);
+    }
+
+    @Test
+    public void test_toString_defaults() {
+        assertEquals(new SAMPRAliasGeneralInformation().toString(), "SAMPR_ALIAS_GENERAL_INFORMATION{Name:null,MemberCount:0,AdminComment:null}");
+    }
+
+    @Test
+    public void test_toString() {
+        SAMPRAliasGeneralInformation obj = new SAMPRAliasGeneralInformation();
+        obj.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
+        obj.setMemberCount(100L);
+        obj.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
+        assertEquals(obj.toString(), "SAMPR_ALIAS_GENERAL_INFORMATION{Name:RPC_UNICODE_STRING{value:\"Name\", nullTerminated:false},MemberCount:100,AdminComment:RPC_UNICODE_STRING{value:\"AdminComment\", nullTerminated:false}}");
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRSRSecurityDescriptor.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRSRSecurityDescriptor.java
@@ -46,7 +46,7 @@ public class Test_SAMPRSRSecurityDescriptor {
     @Test
     public void test_setters() {
         SAMPRSRSecurityDescriptor obj = new SAMPRSRSecurityDescriptor();
-        char[] securityDescriptor = new char[5];
+        byte[] securityDescriptor = new byte[5];
         obj.setSecurityDescriptor(securityDescriptor);
         assertSame(obj.getSecurityDescriptor(), securityDescriptor);
     }
@@ -72,19 +72,19 @@ public class Test_SAMPRSRSecurityDescriptor {
                 {"00000000 00000200", 0, null},
 
                 // Length: 2, Reference: 2
-                {"01000000 00000200", 0, new char[1]},
+                {"01000000 00000200", 0, new byte[1]},
                 // Length: 2, Reference: 2
-                {"02000000 00000200", 0, new char[2]},
+                {"02000000 00000200", 0, new byte[2]},
 
                 // Alignment
-                {"FFFFFFFF 02000000 00000200", 1, new char[2]},
-                {"FFFFFFFF 02000000 00000200", 2, new char[2]},
-                {"FFFFFFFF 02000000 00000200", 3, new char[2]}
+                {"FFFFFFFF 02000000 00000200", 1, new byte[2]},
+                {"FFFFFFFF 02000000 00000200", 2, new byte[2]},
+                {"FFFFFFFF 02000000 00000200", 3, new byte[2]}
         };
     }
 
     @Test(dataProvider = "data_unmarshalEntity")
-    public void test_unmarshalEntity(String hex, int mark, char[] expectedSecurityDescriptor) throws IOException {
+    public void test_unmarshalEntity(String hex, int mark, byte[] expectedSecurityDescriptor) throws IOException {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = new PacketInput(bin);
         in.fullySkipBytes(mark);
@@ -119,19 +119,19 @@ public class Test_SAMPRSRSecurityDescriptor {
         return new Object[][] {
                 // Null
                 {"", 0, null, null},
-                // MaximumCount: 1 SecurityDescriptor: {1, 2, 255}
-                {"01000000 01 02 FF", 0, new char[3], new char[]{1, 2, 255}},
+                // MaximumCount: 1 SecurityDescriptor: {1, 2, -127}
+                {"01000000 01 7F 80", 0, new byte[3], new byte[]{1, Byte.MAX_VALUE, Byte.MIN_VALUE}},
 
                 // Alignment
-                {"FFFFFFFF 01000000 01 02 FF", 1, new char[3], new char[]{1, 2, 255}},
-                {"FFFFFFFF 01000000 01 02 FF", 2, new char[3], new char[]{1, 2, 255}},
-                {"FFFFFFFF 01000000 01 02 FF", 3, new char[3], new char[]{1, 2, 255}},
+                {"FFFFFFFF 01000000 01 7F 80", 1, new byte[3], new byte[]{1, Byte.MAX_VALUE, Byte.MIN_VALUE}},
+                {"FFFFFFFF 01000000 01 7F 80", 2, new byte[3], new byte[]{1, Byte.MAX_VALUE, Byte.MIN_VALUE}},
+                {"FFFFFFFF 01000000 01 7F 80", 3, new byte[3], new byte[]{1, Byte.MAX_VALUE, Byte.MIN_VALUE}},
 
         };
     }
 
     @Test(dataProvider = "data_unmarshalDeferrals")
-    public void test_unmarshalDeferrals(String hex, int mark, char[] securityDescriptor, char[] expectedSecurityDescriptor) throws IOException {
+    public void test_unmarshalDeferrals(String hex, int mark, byte[] securityDescriptor, byte[] expectedSecurityDescriptor) throws IOException {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = new PacketInput(bin);
         in.fullySkipBytes(mark);
@@ -149,9 +149,9 @@ public class Test_SAMPRSRSecurityDescriptor {
         SAMPRSRSecurityDescriptor obj1 = new SAMPRSRSecurityDescriptor();
         SAMPRSRSecurityDescriptor obj2 = new SAMPRSRSecurityDescriptor();
         assertEquals(obj1.hashCode(), obj2.hashCode());
-        obj1.setSecurityDescriptor(new char[5]);
+        obj1.setSecurityDescriptor(new byte[5]);
         assertNotEquals(obj1.hashCode(), obj2.hashCode());
-        obj2.setSecurityDescriptor(new char[5]);
+        obj2.setSecurityDescriptor(new byte[5]);
         assertEquals(obj1.hashCode(), obj2.hashCode());
     }
 
@@ -160,9 +160,9 @@ public class Test_SAMPRSRSecurityDescriptor {
         SAMPRSRSecurityDescriptor obj1 = new SAMPRSRSecurityDescriptor();
         SAMPRSRSecurityDescriptor obj2 = new SAMPRSRSecurityDescriptor();
         assertEquals(obj1, obj2);
-        obj1.setSecurityDescriptor(new char[5]);
+        obj1.setSecurityDescriptor(new byte[5]);
         assertNotEquals(obj1, obj2);
-        obj2.setSecurityDescriptor(new char[5]);
+        obj2.setSecurityDescriptor(new byte[5]);
         assertEquals(obj1, obj2);
     }
 
@@ -174,7 +174,7 @@ public class Test_SAMPRSRSecurityDescriptor {
     @Test
     public void test_toString() {
         SAMPRSRSecurityDescriptor obj = new SAMPRSRSecurityDescriptor();
-        obj.setSecurityDescriptor(new char[]{1, 2, 3});
+        obj.setSecurityDescriptor(new byte[]{1, 2, 3});
         assertEquals(obj.toString(), "SAMPR_SR_SECURITY_DESCRIPTOR{size_of(SecurityDescriptor):3}");
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRUserAllInformation.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRUserAllInformation.java
@@ -173,7 +173,7 @@ public class Test_SAMPRUserAllInformation {
         obj.setPrivateData(privateData);
         assertSame(obj.getPrivateData(), privateData);
         SAMPRSRSecurityDescriptor securityDescriptor = new SAMPRSRSecurityDescriptor();
-        securityDescriptor.setSecurityDescriptor(new char[]{5, 6, 7});
+        securityDescriptor.setSecurityDescriptor(new byte[]{5, 6, 7});
         obj.setSecurityDescriptor(securityDescriptor);
         assertSame(obj.getSecurityDescriptor(), securityDescriptor);
         obj.setUserId(7L);
@@ -320,7 +320,7 @@ public class Test_SAMPRUserAllInformation {
         expectedObj.getLmOwfPassword().setBuffer(new int[]{1, 2, 65535});
         expectedObj.getNtOwfPassword().setBuffer(new int[]{1, 2, 3, 5});
         expectedObj.getPrivateData().setValue("testƟ131");
-        expectedObj.getSecurityDescriptor().setSecurityDescriptor(new char[]{1, 2});
+        expectedObj.getSecurityDescriptor().setSecurityDescriptor(new byte[]{1, 2});
         expectedObj.getLogonHours().setLogonHours(new char[]{3});
 
         String hex =
@@ -464,7 +464,7 @@ public class Test_SAMPRUserAllInformation {
         obj2.setPrivateData(privateData);
         assertEquals(obj1.hashCode(), obj2.hashCode());
         SAMPRSRSecurityDescriptor securityDescriptor = new SAMPRSRSecurityDescriptor();
-        securityDescriptor.setSecurityDescriptor(new char[]{5, 6, 7});
+        securityDescriptor.setSecurityDescriptor(new byte[]{5, 6, 7});
         obj1.setSecurityDescriptor(securityDescriptor);
         assertNotEquals(obj1.hashCode(), obj2.hashCode());
         obj2.setSecurityDescriptor(securityDescriptor);
@@ -623,7 +623,7 @@ public class Test_SAMPRUserAllInformation {
         obj2.setPrivateData(privateData);
         assertEquals(obj1, obj2);
         SAMPRSRSecurityDescriptor securityDescriptor = new SAMPRSRSecurityDescriptor();
-        securityDescriptor.setSecurityDescriptor(new char[]{5, 6, 7});
+        securityDescriptor.setSecurityDescriptor(new byte[]{5, 6, 7});
         obj1.setSecurityDescriptor(securityDescriptor);
         assertNotEquals(obj1, obj2);
         obj2.setSecurityDescriptor(securityDescriptor);
@@ -726,7 +726,7 @@ public class Test_SAMPRUserAllInformation {
         obj.setNtOwfPassword(ntOwfPassword);
         obj.setPrivateData(RPCUnicodeString.NonNullTerminated.of(""));
         SAMPRSRSecurityDescriptor securityDescriptor = new SAMPRSRSecurityDescriptor();
-        securityDescriptor.setSecurityDescriptor(new char[2]);
+        securityDescriptor.setSecurityDescriptor(new byte[2]);
         obj.setSecurityDescriptor(securityDescriptor);
         obj.setUserId(7L);
         obj.setPrimaryGroupId(8L);


### PR DESCRIPTION
- Adds `SamrQuerySecurityObjectRequest`/`Response`
- Adds `SecurityAccountManagerService.getSecurityObject`
- Changed `SAMPRSRSecurityDescriptor` to use `byte[]` instead of `char[]`. The contents of this response is treated as a payload for a SECURITY_DESCRIPTOR and not an array of integers.
- Full unit test coverage