### PR TITLE
Handling PDUType.FAULT and PDUType.REJECT by throwing RPCFaultException

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/PDUFault.java
+++ b/src/main/java/com/rapid7/client/dcerpc/PDUFault.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <a href="http://pubs.opengroup.org/onlinepubs/9629399/apdxe.htm">fault_status Parameter</a>
+ * <blockquote><pre>Both reject and connection-oriented fault PDUs contain a 32-bit field that indicates a server's reason for rejecting an RPC call request.
+ * This field is encoded as the body data of the reject PDU and as the status field of the connection-oriented fault PDU header.</pre></blockquote>
+ *
+ * Reference: <a href="https://github.com/boundary/wireshark/blob/73a610b4e74102eea706985ae454a83582eae0b3/epan/dissectors/packet-dcerpc.c#L265">Wireshark</a>
+ *
+ * Since both rejection and fault codes are unique within the same 32bit integer field,
+ * they are represented here in the same enumeration.
+ */
+public enum PDUFault {
+    UNKNOWN(0x00000000),
+    // DCERPC
+    NCA_S_FAULT_OTHER(0x00000001),
+    NCA_S_FAULT_ACCESS_DENIED(0x00000005),
+    NCA_S_FAULT_NDR(0x000006F7),
+    NCA_S_FAULT_CANT_PERFORM(0x000006D8),
+    NCA_S_FAULT_INT_DIV_BY_ZERO(0x1C000001),
+    NCA_S_FAULT_ADDR_ERROR(0x1C000002),
+    NCA_S_FAULT_FP_DIV_ZERO(0x1C000003),
+    NCA_S_FAULT_FP_UNDERFLOW(0x1C000004),
+    NCA_S_FAULT_FP_OVERFLOW(0x1C000005),
+    NCA_S_FAULT_INVALID_TAG(0x1C000006),
+    NCA_S_FAULT_INVALID_BOUND(0x1C000007),
+    NCA_RPC_VERSION_MISMATCH(0x1C000008),
+    NCA_UNSPEC_REJECT(0x1C000009),
+    NCA_S_BAD_ACTID(0x1C00000A),
+    NCA_WHO_ARE_YOU_FAILED(0x1C00000B),
+    NCA_MANAGER_NOT_ENTERED(0x1C00000C),
+    NCA_S_FAULT_CANCEL(0x1C00000D),
+    NCA_S_FAULT_ILL_INST(0x1C00000E),
+    NCA_S_FAULT_FP_ERROR(0x1C00000F),
+    NCA_S_FAULT_INT_OVERFLOW(0x1C000010),
+    NCA_S_FAULT_PIPE_EMPTY(0x1C000014),
+    NCA_S_FAULT_PIPE_CLOSED(0x1C000015),
+    NCA_S_FAULT_PIPE_ORDER(0x1C000016),
+    NCA_S_FAULT_PIPE_DISCIPLINE(0x1C000017),
+    NCA_S_FAULT_PIPE_COMM_ERROR(0x1C000018),
+    NCA_S_FAULT_PIPE_MEMORY(0x1C000019),
+    NCA_S_FAULT_CONTEXT_MISMATCH(0x1C00001A),
+    NCA_S_FAULT_REMOTE_NO_MEMORY(0x1C00001B),
+    NCA_INVALID_PRES_CONTEXT_ID(0x1C00001C),
+    NCA_UNSUPPORTED_AUTHN_LEVEL(0x1C00001D),
+    NCA_INVALID_CHECKSUM(0x1C00001F),
+    NCA_INVALID_CRC(0x1C000020),
+    NCS_S_FAULT_USER_DEFINED(0x1C000021),
+    NCA_S_FAULT_TX_OPEN_FAILED(0x1C000022),
+    NCA_S_FAULT_CODESET_CONV_ERROR(0x1C000023),
+    NCA_S_FAULT_OBJECT_NOT_FOUND(0x1C000024),
+    NCA_S_FAULT_NO_CLIENT_STUB(0x1C000025),
+    NCA_OP_RNG_ERROR(0x1C010002),
+    NCA_UNK_IF(0x1C010003),
+    NCA_WRONG_BOOT_TIME(0x1C010006),
+    NCA_S_YOU_CRASHED(0x1C010009),
+    NCA_PROTO_ERROR(0x1C01000B),
+    NCA_OUT_ARGS_TOO_BIG(0x1C010013),
+    NCA_SERVER_TOO_BUSY(0x1C010014),
+    NCA_UNSUPPORTED_TYPE(0x1C010017),
+    // Microsoft specific codes
+    E_NOTIMPL(0x80004001),
+    E_POINTER(0x80004003),
+    E_AOBRT(0x80004004),
+    E_UNEXPECTED(0x8000FFFF),
+    RPC_E_SERVERFAULT(0x80010105),
+    RPC_E_DISCONNECTED(0x80010108),
+    RPC_E_INVALID_IPID(0x80010113),
+    RPC_E_TIMEOUT(0x8001011F),
+    DISP_E_MEMBERNOTFOUND(0x80020003),
+    DISP_E_UNKNOWNNAME(0x80020006),
+    DISP_E_BADPARAMCOUNT(0x8002000E),
+    CBA_E_MALFORMED(0x8004CB00),
+    CBA_E_UNKNOWNOBJECT(0x8004CB01),
+    CBA_E_INVALIDID(0x8004CB05),
+    CBA_E_INVALIDCOOKIE(0x8004CB09),
+    CBA_E_QOSTYPEUNSUPPORTED(0x8004CB0B),
+    CBA_E_QOSVALUEUNSUPPORTED(0x8004CB0C),
+    CBA_E_NOTAPPLICABLE(0x8004CB0F),
+    CBA_E_LIMITVIOLATION(0x8004CB12),
+    CBA_E_QOSTYPENOTAPPLICABLE(0x8004CB13),
+    CBA_E_OUTOFPARTNERACCOS(0x8004CB18),
+    CBA_E_FLAGUNSUPPORTED(0x8004CB1C),
+    CBA_E_FRAMECOUNTUNSUPPORTED(0x8004CB23),
+    CBA_E_MODECHANGE(0x8004CB25),
+    E_OUTOFMEMORY(0x8007000E),
+    E_INVALIDARG(0x80070057),
+    RPC_S_PROCNUM_OUT_OF_RANGE(0x800706D1),
+    OR_INVALID_OXID(0x80070776);
+
+    private final int value;
+
+    PDUFault(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+
+    private static final Map<Integer, PDUFault> VALUE_MAP = new HashMap<>();
+    static {
+        for (PDUFault rpcFault : PDUFault.values()) {
+            VALUE_MAP.put(rpcFault.getValue(), rpcFault);
+        }
+    }
+
+    public static PDUFault fromValue(final int value) {
+        final PDUFault ret =  VALUE_MAP.get(value);
+        if (ret == null) {
+            return PDUFault.UNKNOWN;
+        }
+        return ret;
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/transport/exceptions/RPCFaultException.java
+++ b/src/main/java/com/rapid7/client/dcerpc/transport/exceptions/RPCFaultException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.transport.exceptions;
+
+import java.io.EOFException;
+import java.io.IOException;
+import com.rapid7.client.dcerpc.PDUFault;
+import com.rapid7.client.dcerpc.io.PacketInput;
+
+/**
+ * This class represents both PDUType.FAULT and PDUType.REJECT. PDUType.REJECT is unexpected in connection-oriented
+ * calls but maps to the same 32bit fields, so we can catch it with this exception as well.
+ */
+public class RPCFaultException extends IOException {
+
+    public static RPCFaultException read(PacketInput in) throws IOException {
+        int rpcFaultValue;
+        try {
+            rpcFaultValue = in.readInt();
+        } catch (EOFException e) {
+            rpcFaultValue = -1;
+        }
+        return new RPCFaultException(rpcFaultValue);
+    }
+
+    private final int rpcFaultValue;
+    private final PDUFault rpcFault;
+
+    public RPCFaultException(final int rpcFaultValue) {
+        this.rpcFaultValue = rpcFaultValue;
+        this.rpcFault = PDUFault.fromValue(this.rpcFaultValue);
+    }
+
+    public int getRpcFaultValue() {
+        return rpcFaultValue;
+    }
+
+    public PDUFault getRpcFault() {
+        return rpcFault;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format("Fault: %s (0x%08X)", getRpcFault(), getRpcFaultValue());
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/Test_RPCFault.java
+++ b/src/test/java/com/rapid7/client/dcerpc/Test_RPCFault.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class Test_RPCFault {
+
+    @Test(dataProvider = "data_pairs")
+    public void test_fromValue(PDUFault expectFault, long value) {
+        assertEquals(PDUFault.fromValue((int) value), expectFault);
+    }
+
+    @Test(dataProvider = "data_pairs")
+    public void test_getValue(PDUFault fault, long expectValue) {
+        assertEquals(fault.getValue(), (int) expectValue);
+    }
+
+    @Test(dataProvider = "data_pairs")
+    public void test_toString(PDUFault fault, long value) {
+        assertEquals(fault.toString(), fault.name().toLowerCase());
+    }
+
+    @DataProvider
+    public Object[][] data_pairs() {
+        return new Object[][] {
+                {PDUFault.UNKNOWN, 0},
+                {PDUFault.NCA_S_FAULT_OTHER, 1},
+                {PDUFault.NCA_S_FAULT_ACCESS_DENIED, 5},
+                {PDUFault.NCA_S_FAULT_NDR, 1783},
+                {PDUFault.NCA_S_FAULT_CANT_PERFORM, 1752},
+                {PDUFault.NCA_S_FAULT_INT_DIV_BY_ZERO, 469762049},
+                {PDUFault.NCA_S_FAULT_ADDR_ERROR, 469762050},
+                {PDUFault.NCA_S_FAULT_FP_DIV_ZERO, 469762051},
+                {PDUFault.NCA_S_FAULT_FP_UNDERFLOW, 469762052},
+                {PDUFault.NCA_S_FAULT_FP_OVERFLOW, 469762053},
+                {PDUFault.NCA_S_FAULT_INVALID_TAG, 469762054},
+                {PDUFault.NCA_S_FAULT_INVALID_BOUND, 469762055},
+                {PDUFault.NCA_RPC_VERSION_MISMATCH, 469762056},
+                {PDUFault.NCA_UNSPEC_REJECT, 469762057},
+                {PDUFault.NCA_S_BAD_ACTID, 469762058},
+                {PDUFault.NCA_WHO_ARE_YOU_FAILED, 469762059},
+                {PDUFault.NCA_MANAGER_NOT_ENTERED, 469762060},
+                {PDUFault.NCA_S_FAULT_CANCEL, 469762061},
+                {PDUFault.NCA_S_FAULT_ILL_INST, 469762062},
+                {PDUFault.NCA_S_FAULT_FP_ERROR, 469762063},
+                {PDUFault.NCA_S_FAULT_INT_OVERFLOW, 469762064},
+                {PDUFault.NCA_S_FAULT_PIPE_EMPTY, 469762068},
+                {PDUFault.NCA_S_FAULT_PIPE_CLOSED, 469762069},
+                {PDUFault.NCA_S_FAULT_PIPE_ORDER, 469762070},
+                {PDUFault.NCA_S_FAULT_PIPE_DISCIPLINE, 469762071},
+                {PDUFault.NCA_S_FAULT_PIPE_COMM_ERROR, 469762072},
+                {PDUFault.NCA_S_FAULT_PIPE_MEMORY, 469762073},
+                {PDUFault.NCA_S_FAULT_CONTEXT_MISMATCH, 469762074},
+                {PDUFault.NCA_S_FAULT_REMOTE_NO_MEMORY, 469762075},
+                {PDUFault.NCA_INVALID_PRES_CONTEXT_ID, 469762076},
+                {PDUFault.NCA_UNSUPPORTED_AUTHN_LEVEL, 469762077},
+                {PDUFault.NCA_INVALID_CHECKSUM, 469762079},
+                {PDUFault.NCA_INVALID_CRC, 469762080},
+                {PDUFault.NCS_S_FAULT_USER_DEFINED, 469762081},
+                {PDUFault.NCA_S_FAULT_TX_OPEN_FAILED, 469762082},
+                {PDUFault.NCA_S_FAULT_CODESET_CONV_ERROR, 469762083},
+                {PDUFault.NCA_S_FAULT_OBJECT_NOT_FOUND, 469762084},
+                {PDUFault.NCA_S_FAULT_NO_CLIENT_STUB, 469762085},
+                {PDUFault.NCA_OP_RNG_ERROR, 469827586},
+                {PDUFault.NCA_UNK_IF, 469827587},
+                {PDUFault.NCA_WRONG_BOOT_TIME, 469827590},
+                {PDUFault.NCA_S_YOU_CRASHED, 469827593},
+                {PDUFault.NCA_PROTO_ERROR, 469827595},
+                {PDUFault.NCA_OUT_ARGS_TOO_BIG, 469827603},
+                {PDUFault.NCA_SERVER_TOO_BUSY, 469827604},
+                {PDUFault.NCA_UNSUPPORTED_TYPE, 469827607},
+                {PDUFault.E_NOTIMPL, 2147500033L},
+                {PDUFault.E_POINTER, 2147500035L},
+                {PDUFault.E_AOBRT, 2147500036L},
+                {PDUFault.E_UNEXPECTED, 2147549183L},
+                {PDUFault.RPC_E_SERVERFAULT, 2147549445L},
+                {PDUFault.RPC_E_DISCONNECTED, 2147549448L},
+                {PDUFault.RPC_E_INVALID_IPID, 2147549459L},
+                {PDUFault.RPC_E_TIMEOUT, 2147549471L},
+                {PDUFault.DISP_E_MEMBERNOTFOUND, 2147614723L},
+                {PDUFault.DISP_E_UNKNOWNNAME, 2147614726L},
+                {PDUFault.DISP_E_BADPARAMCOUNT, 2147614734L},
+                {PDUFault.CBA_E_MALFORMED, 2147797760L},
+                {PDUFault.CBA_E_UNKNOWNOBJECT, 2147797761L},
+                {PDUFault.CBA_E_INVALIDID, 2147797765L},
+                {PDUFault.CBA_E_INVALIDCOOKIE, 2147797769L},
+                {PDUFault.CBA_E_QOSTYPEUNSUPPORTED, 2147797771L},
+                {PDUFault.CBA_E_QOSVALUEUNSUPPORTED, 2147797772L},
+                {PDUFault.CBA_E_NOTAPPLICABLE, 2147797775L},
+                {PDUFault.CBA_E_LIMITVIOLATION, 2147797778L},
+                {PDUFault.CBA_E_QOSTYPENOTAPPLICABLE, 2147797779L},
+                {PDUFault.CBA_E_OUTOFPARTNERACCOS, 2147797784L},
+                {PDUFault.CBA_E_FLAGUNSUPPORTED, 2147797788L},
+                {PDUFault.CBA_E_FRAMECOUNTUNSUPPORTED, 2147797795L},
+                {PDUFault.CBA_E_MODECHANGE, 2147797797L},
+                {PDUFault.E_OUTOFMEMORY, 2147942414L},
+                {PDUFault.E_INVALIDARG, 2147942487L},
+                {PDUFault.RPC_S_PROCNUM_OUT_OF_RANGE, 2147944145L},
+                {PDUFault.OR_INVALID_OXID, 2147944310L}
+        };
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/transport/exceptions/Test_RPCFaultException.java
+++ b/src/test/java/com/rapid7/client/dcerpc/transport/exceptions/Test_RPCFaultException.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.transport.exceptions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import com.rapid7.client.dcerpc.PDUFault;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class Test_RPCFaultException {
+
+    @DataProvider
+    public Object[][] data_read_known() {
+        PDUFault[] faults = PDUFault.values();
+
+        Object[][] ret = new Object[faults.length][];
+        for (int i = 0; i < faults.length; i++) {
+            ret[i] = new Object[]{faults[i]};
+        }
+        return ret;
+    }
+
+    @Test(dataProvider = "data_read_known")
+    public void test_read_known(PDUFault fault) throws IOException {
+        // Set up the buffer
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        PacketOutput out = new PacketOutput(bout);
+        out.writeInt(fault.getValue());
+        ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
+        PacketInput in = new PacketInput(bin);
+        // Test
+        RPCFaultException ex = RPCFaultException.read(in);
+        assertSame(ex.getRpcFault(), fault);
+        assertEquals(ex.getRpcFaultValue(), fault.getValue());
+        assertTrue(ex.getMessage().startsWith("Fault: " + fault.toString()));
+        assertEquals(bin.available(), 0);
+    }
+
+    @DataProvider
+    public Object[][] data_read_unknown() {
+        return new Object[][] {
+                // Actually UKNOWN
+                {"00000000", 0},
+                // Unknown number
+                {"09000000", 9},
+                // Insufficient bytes
+                {"", -1},
+                {"00", -1},
+        };
+    }
+
+    @Test(dataProvider = "data_read_unknown")
+    public void test_read_unknown(String hex, int expectValue) throws IOException {
+        // Set up the buffer
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        // Test
+        RPCFaultException ex = RPCFaultException.read(in);
+        assertSame(ex.getRpcFault(), PDUFault.UNKNOWN);
+        assertEquals(ex.getRpcFaultValue(), expectValue);
+        assertEquals(bin.available(), 0);
+    }
+}


### PR DESCRIPTION
Previously, we would attempt to unmarshall the response regardless of the PDU. However, we should only attempt this when the PDU is RESPONSE, otherwise the payload is not what will be expected.

- RPCFault has been added which capture all well known FAULT and REJECT codes
- RPCFaultException has been added which holds the context of the FAULT or REJECT response
- In the event that the PDU returned from our request is not RESPONSE but is FAULT or REJECT, we will best-effort parse the fault/reject code, and throw RPCFaultException
- In the event that the PDU returned from our request is not RESPONSE but is not FAULT and not REJECT, we will throw a generic IOException