### PR TITLE
RequestResponse now automatically parses the return value

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/messages/HandleResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/messages/HandleResponse.java
@@ -39,7 +39,6 @@ import com.rapid7.client.dcerpc.objects.ContextHandle;
  */
 public class HandleResponse<T extends ContextHandle> extends RequestResponse {
     private final T handle = initHandle();
-    private int returnValue;
 
     /**
      * @return The handle to a opened key.
@@ -48,17 +47,8 @@ public class HandleResponse<T extends ContextHandle> extends RequestResponse {
         return handle;
     }
 
-    /**
-     * @return The method returns 0 (ERROR_SUCCESS) to indicate success; otherwise,
-     * it returns a nonzero error code, as
-     * specified in [MS-ERREF] section 2.2.
-     */
-    public int getReturnValue() {
-        return returnValue;
-    }
-
     @Override
-    public void unmarshal(final PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
         // Remote Registry Service, OpenHKLM
         // Operation: OpenHKLM (2)
         // [Request in frame: 11174]
@@ -69,7 +59,6 @@ public class HandleResponse<T extends ContextHandle> extends RequestResponse {
         // [Frame handle closed: 11424]
         // Windows Error: WERR_OK (0x00000000)
         packetIn.readUnmarshallable(handle);
-        returnValue = packetIn.readInt();
     }
 
     /**

--- a/src/main/java/com/rapid7/client/dcerpc/messages/RequestResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/messages/RequestResponse.java
@@ -28,7 +28,7 @@ import com.rapid7.client.dcerpc.mserref.SystemErrorCode;
 
 public abstract class RequestResponse extends HexifyImpl implements Packet, Hexify {
 
-    private int returnCode;
+    private int returnValue;
 
     /**
      * @return The method returns 0 (ERROR_SUCCESS) to indicate success; otherwise, it returns a nonzero error code, as
@@ -68,7 +68,7 @@ public abstract class RequestResponse extends HexifyImpl implements Packet, Hexi
      * </table>
      */
     public int getReturnValue() {
-        return returnCode;
+        return returnValue;
     }
 
     public SystemErrorCode getReturnCode() {
@@ -82,7 +82,7 @@ public abstract class RequestResponse extends HexifyImpl implements Packet, Hexi
     @Override
     public void unmarshal(PacketInput packetIn) throws IOException {
         unmarshalResponse(packetIn);
-        this.returnCode = packetIn.readInt();
+        this.returnValue = packetIn.readInt();
     }
 
     public abstract void unmarshalResponse(PacketInput packetIn) throws IOException;

--- a/src/main/java/com/rapid7/client/dcerpc/messages/RequestResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/messages/RequestResponse.java
@@ -22,9 +22,71 @@ import java.io.IOException;
 import com.rapid7.client.dcerpc.io.Hexify;
 import com.rapid7.client.dcerpc.io.HexifyImpl;
 import com.rapid7.client.dcerpc.io.Packet;
+import com.rapid7.client.dcerpc.io.PacketInput;
 import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.mserref.SystemErrorCode;
 
 public abstract class RequestResponse extends HexifyImpl implements Packet, Hexify {
+
+    private int returnCode;
+
+    /**
+     * @return The method returns 0 (ERROR_SUCCESS) to indicate success; otherwise, it returns a nonzero error code, as
+     * specified in {@link com.rapid7.client.dcerpc.mserref.SystemErrorCode} in [MS-ERREF]. The most common
+     * error codes are listed in the following table.<br>
+     * <br>
+     * <table border="1" summary="">
+     * <tr>
+     * <td>Return value/code</td>
+     * <td>Description</td>
+     * <tr>
+     * <tr>
+     * <td>ERROR_ACCESS_DENIED (0x00000005)</td>
+     * <td>The caller does not have KEY_ENUMERATE_SUB_KEYS access rights.</td>
+     * </tr>
+     * <tr>
+     * <td>ERROR_OUTOFMEMORY (0x0000000E)</td>
+     * <td>Not enough storage is available to complete this operation.</td>
+     * </tr>
+     * <tr>
+     * <td>ERROR_INVALID_PARAMETER (0x00000057)</td>
+     * <td>A parameter is incorrect.</td>
+     * </tr>
+     * <tr>
+     * <td>ERROR_NO_MORE_ITEMS (0x00000103)</td>
+     * <td>No more data is available.</td>
+     * </tr>
+     * <tr>
+     * <td>ERROR_WRITE_PROTECT (0x00000013)</td>
+     * <td>A read or write operation was attempted to a volume after it was dismounted. The server can no longer
+     * service registry requests because server shutdown has been initiated.</td>
+     * </tr>
+     * <tr>
+     * <td>ERROR_MORE_DATA (0x000000EA)</td>
+     * <td>The size of the buffer is not large enough to hold the requested data.</td>
+     * </tr>
+     * </table>
+     */
+    public int getReturnValue() {
+        return returnCode;
+    }
+
+    public SystemErrorCode getReturnCode() {
+        return SystemErrorCode.getErrorCode(getReturnValue());
+    }
+
+    public boolean isSuccess() {
+        return getReturnCode() == SystemErrorCode.ERROR_SUCCESS;
+    }
+
+    @Override
+    public void unmarshal(PacketInput packetIn) throws IOException {
+        unmarshalResponse(packetIn);
+        this.returnCode = packetIn.readInt();
+    }
+
+    public abstract void unmarshalResponse(PacketInput packetIn) throws IOException;
+
     @Override
     public void marshal(final PacketOutput packetOut) throws IOException {
         throw new UnsupportedOperationException("Marshal Not Implemented.");

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarClosePolicyRpcResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarClosePolicyRpcResponse.java
@@ -30,7 +30,7 @@ public class LsarClosePolicyRpcResponse extends RequestResponse {
     }
 
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
       /*
        * Rpc Info
        *
@@ -51,5 +51,4 @@ public class LsarClosePolicyRpcResponse extends RequestResponse {
        */
         handle = packetIn.readRawBytes(20);
     }
-
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupAcctPrivsRpcResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupAcctPrivsRpcResponse.java
@@ -24,18 +24,13 @@ import com.rapid7.client.dcerpc.messages.RequestResponse;
 
 public class LsarLookupAcctPrivsRpcResponse extends RequestResponse {
     private String[] privNames;
-    private int returnValue;
 
     public String[] getPrivNames() {
         return privNames;
     }
 
-    public int getReturnValue() {
-        return returnValue;
-    }
-
     @Override
-    public void unmarshal(final PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
       /*
        * Rpc Info
        *
@@ -73,8 +68,6 @@ public class LsarLookupAcctPrivsRpcResponse extends RequestResponse {
                 privNames[i] = packetIn.readString(true);
             }
         }
-
-        returnValue = packetIn.readInt();
     }
 }
 

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupNamesResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupNamesResponse.java
@@ -51,12 +51,11 @@ import java.io.IOException;
  */
 
 public class LsarLookupNamesResponse extends RequestResponse {
-    private int returnValue;
     private LSAPRReferencedDomainList lsaprReferencedDomainList;
     private LSAPRTranslatedSIDs lsaprTranslatedSIDs;
 
     @Override
-    public void unmarshal(final PacketInput packetIn)
+    public void unmarshalResponse(final PacketInput packetIn)
             throws IOException {
 
         //Top level parameters
@@ -73,8 +72,6 @@ public class LsarLookupNamesResponse extends RequestResponse {
 
         //3. Mapped Count
         packetIn.readInt();
-
-        returnValue = packetIn.readInt();
     }
 
     public LSAPRReferencedDomainList getLsaprReferencedDomainList() {
@@ -91,9 +88,5 @@ public class LsarLookupNamesResponse extends RequestResponse {
 
     public void setLsaprTranslatedSIDs(LSAPRTranslatedSIDs lsaprTranslatedSIDs) {
         this.lsaprTranslatedSIDs = lsaprTranslatedSIDs;
-    }
-
-    public int getReturnValue() {
-        return returnValue;
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupSidsWithAcctPrivRpcResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupSidsWithAcctPrivRpcResponse.java
@@ -25,18 +25,13 @@ import com.rapid7.client.dcerpc.messages.RequestResponse;
 
 public class LsarLookupSidsWithAcctPrivRpcResponse extends RequestResponse {
     private SID[] sids;
-    private int returnValue;
 
     public SID[] getSids() {
         return sids;
     }
 
-    public int getReturnValue() {
-        return returnValue;
-    }
-
     @Override
-    public void unmarshal(final PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
       /* Rpc Info
        *
        * MajorVer:    05
@@ -82,8 +77,6 @@ public class LsarLookupSidsWithAcctPrivRpcResponse extends RequestResponse {
                 sids[i] = read(packetIn);
             }
         }
-
-        returnValue = packetIn.readInt();
     }
 
     public SID read(PacketInput packetIn) throws IOException {

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarQueryInformationPolicyResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarQueryInformationPolicyResponse.java
@@ -40,7 +40,7 @@ public abstract class LsarQueryInformationPolicyResponse<T extends Unmarshallabl
     }
 
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         if(packetIn.readReferentID() != 0) {
             final int infoLevel = packetIn.readUnsignedShort();
             if (infoLevel != getPolicyInformationClass().getInfoLevel()) {

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/RegistryService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/RegistryService.java
@@ -26,6 +26,7 @@ import com.rapid7.client.dcerpc.RPCException;
 import com.rapid7.client.dcerpc.messages.HandleResponse;
 import com.rapid7.client.dcerpc.msrrp.messages.*;
 import com.rapid7.client.dcerpc.objects.ContextHandle;
+import com.rapid7.client.dcerpc.objects.FileTime;
 import com.rapid7.client.dcerpc.transport.RPCTransport;
 
 import static com.rapid7.client.dcerpc.mserref.SystemErrorCode.ERROR_NO_MORE_ITEMS;
@@ -108,7 +109,7 @@ public class RegistryService {
             final int returnCode = response.getReturnValue();
 
             if (ERROR_SUCCESS.is(returnCode)) {
-                keyNames.add(new RegistryKey(response.getName(), response.getLastWriteTime()));
+                keyNames.add(new RegistryKey(response.getName(), new FileTime(response.getLastWriteTime())));
             } else if (ERROR_NO_MORE_ITEMS.is(returnCode)) {
                 return Collections.unmodifiableList(new ArrayList<RegistryKey>(keyNames));
             } else {

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegEnumKeyResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegEnumKeyResponse.java
@@ -72,8 +72,7 @@ import static com.rapid7.client.dcerpc.mserref.SystemErrorCode.ERROR_SUCCESS;
  */
 public class BaseRegEnumKeyResponse extends RequestResponse {
     private String name;
-    private FileTime lastWriteTime;
-    private int returnValue;
+    private long lastWriteTime;
 
     /**
      * @return The name of the retrieved key.
@@ -85,53 +84,12 @@ public class BaseRegEnumKeyResponse extends RequestResponse {
     /**
      * @return The time when a value was last written (set or created).
      */
-    public FileTime getLastWriteTime() {
+    public long getLastWriteTime() {
         return lastWriteTime;
     }
 
-    /**
-     * @return The method returns 0 (ERROR_SUCCESS) to indicate success; otherwise, it returns a nonzero error code, as
-     * specified in {@link com.rapid7.client.dcerpc.mserref.SystemErrorCode} in [MS-ERREF]. The most common
-     * error codes are listed in the following table.<br>
-     * <br>
-     * <table border="1" summary="">
-     * <tr>
-     * <td>Return value/code</td>
-     * <td>Description</td>
-     * <tr>
-     * <tr>
-     * <td>ERROR_ACCESS_DENIED (0x00000005)</td>
-     * <td>The caller does not have KEY_ENUMERATE_SUB_KEYS access rights.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_OUTOFMEMORY (0x0000000E)</td>
-     * <td>Not enough storage is available to complete this operation.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_INVALID_PARAMETER (0x00000057)</td>
-     * <td>A parameter is incorrect.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_NO_MORE_ITEMS (0x00000103)</td>
-     * <td>No more data is available.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_WRITE_PROTECT (0x00000013)</td>
-     * <td>A read or write operation was attempted to a volume after it was dismounted. The server can no longer
-     * service registry requests because server shutdown has been initiated.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_MORE_DATA (0x000000EA)</td>
-     * <td>The size of the buffer is not large enough to hold the requested data.</td>
-     * </tr>
-     * </table>
-     */
-    public int getReturnValue() {
-        return returnValue;
-    }
-
     @Override
-    public void unmarshal(final PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
         // Remote Registry Service, EnumKey
         //      Operation: EnumKey (9)
         //      [Request in frame: 11177]
@@ -171,18 +129,8 @@ public class BaseRegEnumKeyResponse extends RequestResponse {
         //          Referent ID: 0x0002000c
         //          Last Changed Time: Jun 15, 2017 15:29:36.566813400 EDT
         //      Windows Error: WERR_OK (0x00000000)
-        final String name = packetIn.readStringBuf(true);
+        this.name = packetIn.readStringBuf(true);
         packetIn.readStringBufRef(true);
-        final long lastWriteTime = packetIn.readLongRef();
-
-        returnValue = packetIn.readInt();
-
-        if (ERROR_SUCCESS.is(returnValue)) {
-            this.name = name;
-            this.lastWriteTime = new FileTime(lastWriteTime);
-        } else {
-            this.name = null;
-            this.lastWriteTime = null;
-        }
+        this.lastWriteTime = packetIn.readLongRef();
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegEnumValueResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegEnumValueResponse.java
@@ -77,7 +77,6 @@ public class BaseRegEnumValueResponse extends RequestResponse {
     private String name;
     private RegistryValueType type;
     private byte[] data;
-    private int returnValue;
 
     /**
      * @return The retrieved value name.
@@ -100,49 +99,8 @@ public class BaseRegEnumValueResponse extends RequestResponse {
         return data;
     }
 
-    /**
-     * @return The method returns 0 (ERROR_SUCCESS) to indicate success; otherwise, it returns a nonzero error code, as
-     * specified in {@link com.rapid7.client.dcerpc.mserref.SystemErrorCode} in [MS-ERREF]. The most common
-     * error codes are listed in the following table.<br>
-     * <br>
-     * <table border="1" summary="">
-     * <tr>
-     * <td>ERROR_ACCESS_DENIED (0x00000005)</td>
-     * <td>The caller does not have KEY_QUERY_VALUE access rights.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_OUTOFMEMORY (0x0000000E)</td>
-     * <td>Not enough storage is available to complete this operation.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_INVALID_PARAMETER (0x00000057)</td>
-     * <td>A parameter is incorrect.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_INSUFFICIENT_BUFFER (0x0000007A)</td>
-     * <td>The data area passed to a system call is too small.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_MORE_DATA (0x000000EA)</td>
-     * <td>More data is available.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_NO_MORE_ITEMS (0x00000103)</td>
-     * <td>No more data is available.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_WRITE_PROTECT (0x00000013)</td>
-     * <td>A read or write operation was attempted to a volume after it was dismounted. The server can no longer
-     * service registry requests because server shutdown has been initiated.</td>
-     * </tr>
-     * </table>
-     */
-    public int getReturnValue() {
-        return returnValue;
-    }
-
     @Override
-    public void unmarshal(final PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
         // Remote Registry Service, EnumValue
         //      Operation: EnumValue (10)
         //      [Request in frame: 11206]
@@ -203,23 +161,11 @@ public class BaseRegEnumValueResponse extends RequestResponse {
         //          Referent ID: 0x00020010
         //          Length: 22
         //      Windows Error: WERR_OK (0x00000000)
-        final String name = packetIn.readStringBuf(true);
-        final int type = packetIn.readIntRef();
-        final byte[] data = packetIn.readByteArrayRef();
+        this.name = packetIn.readStringBuf(true);
+        this.type = RegistryValueType.getRegistryValueType(packetIn.readIntRef());
+        this.data = packetIn.readByteArrayRef();
 
         packetIn.readIntRef();
         packetIn.readIntRef();
-
-        returnValue = packetIn.readInt();
-
-        if (ERROR_SUCCESS.is(returnValue)) {
-            this.name = name;
-            this.type = RegistryValueType.getRegistryValueType(type);
-            this.data = data;
-        } else {
-            this.name = null;
-            this.type = null;
-            this.data = null;
-        }
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegQueryInfoKeyResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegQueryInfoKeyResponse.java
@@ -62,7 +62,6 @@ public class BaseRegQueryInfoKeyResponse extends RequestResponse {
     private int maxValueLen;
     private int securityDescriptor;
     private long lastWriteTime;
-    private int returnValue;
 
     /**
      * @return The count of the subkeys of the specified key.
@@ -120,40 +119,8 @@ public class BaseRegQueryInfoKeyResponse extends RequestResponse {
         return lastWriteTime;
     }
 
-    /**
-     * @return The method returns 0 (ERROR_SUCCESS) to indicate success; otherwise, it returns a nonzero error code, as
-     * specified in {@link com.rapid7.client.dcerpc.mserref.SystemErrorCode} in [MS-ERREF]. The most common
-     * error codes are listed in the following table.
-     * <table border="1" summary="">
-     * <tr>
-     * <td>Return value/code</td>
-     * <td>Description</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_ACCESS_DENIED (0x00000005)</td>
-     * <td>The caller does not have KEY_QUERY_VALUE access rights.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_INVALID_PARAMETER (0x00000057)</td>
-     * <td>A parameter is incorrect.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_WRITE_PROTECT (0x00000013)</td>
-     * <td>A read or write operation was attempted to a volume after it was dismounted. The server can no longer
-     * service registry requests because server shutdown has been initiated.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_MORE_DATA (0x000000EA)</td>
-     * <td>The size of the buffer is not large enough to hold the requested data.</td>
-     * </tr>
-     * </table>
-     */
-    public int getReturnValue() {
-        return returnValue;
-    }
-
     @Override
-    public void unmarshal(final PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
         // Remote Registry Service, QueryInfoKey
         //      Operation: QueryInfoKey (16)
         //      [Request in frame: 11405]
@@ -189,6 +156,5 @@ public class BaseRegQueryInfoKeyResponse extends RequestResponse {
         maxValueLen = packetIn.readInt();
         securityDescriptor = packetIn.readInt();
         lastWriteTime = packetIn.readLong();
-        returnValue = packetIn.readInt();
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegQueryValueResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegQueryValueResponse.java
@@ -60,7 +60,6 @@ import static com.rapid7.client.dcerpc.mserref.SystemErrorCode.ERROR_SUCCESS;
 public class BaseRegQueryValueResponse extends RequestResponse {
     private RegistryValueType type;
     private byte[] data;
-    private int returnValue;
 
     /**
      * @return The {@link RegistryValueType} of the value.
@@ -76,45 +75,8 @@ public class BaseRegQueryValueResponse extends RequestResponse {
         return data;
     }
 
-    /**
-     * @return The method returns 0 (ERROR_SUCCESS) to indicate success; otherwise, it returns a nonzero error code, as
-     * specified in {@link com.rapid7.client.dcerpc.mserref.SystemErrorCode} in [MS-ERREF]. The most common
-     * error codes are listed in the following table.
-     * <table border="1" summary="">
-     * <tr>
-     * <td>Return value/code</td>
-     * <td>Description</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_ACCESS_DENIED (0x00000005)</td>
-     * <td>The caller does not have KEY_QUERY_VALUE access rights.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_INVALID_PARAMETER (0x00000057)</td>
-     * <td>A parameter is incorrect.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_FILE_NOT_FOUND (0x00000002)</td>
-     * <td>The value specified by lpValueName was not found. If lpValueName was not specified, the default value
-     * has not been defined.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_WRITE_PROTECT (0x00000013)</td>
-     * <td>A read or write operation was attempted to a volume after it was dismounted. The server can no longer
-     * service registry requests because server shutdown has been initiated.</td>
-     * </tr>
-     * <tr>
-     * <td>ERROR_MORE_DATA (0x000000EA)</td>
-     * <td>The data to be returned is larger than the buffer provided.</td>
-     * </tr>
-     * </table>
-     */
-    public int getReturnValue() {
-        return returnValue;
-    }
-
     @Override
-    public void unmarshal(final PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
         // Remote Registry Service, QueryValue
         //      Operation: QueryValue (17)
         //      [Request in frame: 11394]
@@ -141,19 +103,9 @@ public class BaseRegQueryValueResponse extends RequestResponse {
         //          Referent ID: 0x0002000c
         //          Data Length: 8
         //      Windows Error: WERR_OK (0x00000000)
-        final int type = packetIn.readIntRef();
-        final byte[] data = packetIn.readByteArrayRef();
+        this.type = RegistryValueType.getRegistryValueType(packetIn.readIntRef());
+        this.data = packetIn.readByteArrayRef();
         packetIn.readIntRef();
         packetIn.readIntRef();
-
-        returnValue = packetIn.readInt();
-
-        if (ERROR_SUCCESS.is(returnValue)) {
-            this.type = RegistryValueType.getRegistryValueType(type);
-            this.data = data;
-        } else {
-            this.type = null;
-            this.data = null;
-        }
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrCloseHandleResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrCloseHandleResponse.java
@@ -24,16 +24,10 @@ import com.rapid7.client.dcerpc.messages.RequestResponse;
 import com.rapid7.client.dcerpc.objects.ContextHandle;
 
 public class SamrCloseHandleResponse extends RequestResponse {
-    private int returnValue;
 
     @Override
-    public void unmarshal(PacketInput in) throws IOException {
+    public void unmarshalResponse(PacketInput in) throws IOException {
         // SAMR handle is 20 bytes
         in.readUnmarshallable(new ContextHandle());
-        returnValue = in.readInt();
-    }
-
-    public int getReturnValue() {
-        return returnValue;
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrEnumerateResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrEnumerateResponse.java
@@ -28,13 +28,13 @@ public abstract class SamrEnumerateResponse extends RequestResponse {
 
     private int resumeHandle;
     private int numEntries;
-    private int returnCode;
 
     protected abstract void unmarshallBuffer(PacketInput packetIn) throws IOException;
 
     public abstract List getList();
+
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         // <NDR: unsigned long> [in, out] unsigned long* EnumerationContext,
         // Alignment: 4 - Already aligned
         resumeHandle = packetIn.readInt();
@@ -46,7 +46,6 @@ public abstract class SamrEnumerateResponse extends RequestResponse {
         // <NDR: unsigned long> [out] unsigned long* CountReturned
         packetIn.align(Alignment.FOUR);
         numEntries = packetIn.readInt();
-        returnCode = packetIn.readInt();
     }
 
     public int getNumEntries() {
@@ -55,9 +54,5 @@ public abstract class SamrEnumerateResponse extends RequestResponse {
 
     public int getResumeHandle() {
         return resumeHandle;
-    }
-
-    public int getReturnValue() {
-        return returnCode;
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrGetGroupsForUserResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrGetGroupsForUserResponse.java
@@ -30,7 +30,6 @@ import com.rapid7.client.dcerpc.mssamr.objects.SAMPRGetGroupsBuffer;
  */
 public class SamrGetGroupsForUserResponse extends RequestResponse {
     private SAMPRGetGroupsBuffer buffer;
-    private int returnValue;
 
     public List<GroupMembership> getGroupMembership() {
         if (buffer == null)
@@ -38,18 +37,13 @@ public class SamrGetGroupsForUserResponse extends RequestResponse {
         return buffer.getEntries();
     }
 
-    public int getReturnValue() {
-        return returnValue;
-    }
-
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         buffer = new SAMPRGetGroupsBuffer();
         int ref = packetIn.readReferentID();
         if (ref != 0)
             packetIn.readUnmarshallable(buffer);
         else
             buffer = null;
-        returnValue = packetIn.readInt();
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryDisplayInformation2Response.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryDisplayInformation2Response.java
@@ -31,14 +31,11 @@ import com.rapid7.client.dcerpc.mssamr.objects.SAMPRDomainDisplayGroupBuffer;
 /**
  * The {@link SamrEnumerateResponse} implementation for request {@link SamrQueryDisplayInformation2Request}.
  */
-public class SamrQueryDisplayInformation2Response<T extends Unmarshallable>
-        extends RequestResponse
-{
+public class SamrQueryDisplayInformation2Response<T extends Unmarshallable> extends RequestResponse {
     private final DisplayInformationClass infoClass;
     private int totalAvailableBytes;
     private int totalReturnedBytes;
     private SAMPRDisplayInfoBuffer buffer;
-    private int returnCode;
 
     public SamrQueryDisplayInformation2Response(DisplayInformationClass infoClass) {
         this.infoClass = infoClass;
@@ -58,17 +55,12 @@ public class SamrQueryDisplayInformation2Response<T extends Unmarshallable>
         return buffer.getEntries();
     }
 
-    public int getReturnValue() {
-        return returnCode;
-    }
-
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         totalAvailableBytes = packetIn.readInt();
         totalReturnedBytes = packetIn.readInt();
         unmarshallBuffer(packetIn);
         packetIn.align();
-        returnCode = packetIn.readInt();
     }
 
     private void unmarshallBuffer(PacketInput packetIn) throws IOException {

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationAliasResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationAliasResponse.java
@@ -41,7 +41,7 @@ public abstract class SamrQueryInformationAliasResponse<T extends Unmarshallable
     abstract T createAliasInformation();
 
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         if(packetIn.readReferentID() != 0) {
             final int infoLevel = packetIn.readUnsignedShort();
             if (infoLevel != getAliasInformationClass().getInfoLevel()) {

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationDomainResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationDomainResponse.java
@@ -38,7 +38,7 @@ public class SamrQueryInformationDomainResponse<T extends Unmarshallable> extend
     }
 
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         if (packetIn.readReferentID() != 0) {
             final int infoLevel = packetIn.readShort();
             if (infoLevel != this.domainInformationClass.getInfoLevel()) {

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationGroupResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationGroupResponse.java
@@ -43,7 +43,7 @@ public abstract class SamrQueryInformationGroupResponse<T extends Unmarshallable
     abstract T createGroupInformation();
 
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         if(packetIn.readReferentID() != 0) {
             final int infoLevel = packetIn.readUnsignedShort();
             if (infoLevel != getGroupInformationClass().getInfoLevel()) {

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationUserResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationUserResponse.java
@@ -41,7 +41,7 @@ public abstract class SamrQueryInformationUserResponse<T extends Unmarshallable>
     abstract T createUserInformation();
 
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         if(packetIn.readReferentID() != 0) {
             final int infoLevel = packetIn.readUnsignedShort();
             if (infoLevel != getUserInformationClass().getInfoLevel()) {

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQuerySecurityObjectResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQuerySecurityObjectResponse.java
@@ -36,7 +36,7 @@ public class SamrQuerySecurityObjectResponse extends RequestResponse {
     }
 
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         if (packetIn.readReferentID() != 0) {
             this.securityDescriptor = new SAMPRSRSecurityDescriptor();
             packetIn.readUnmarshallable(this.securityDescriptor);

--- a/src/main/java/com/rapid7/client/dcerpc/mssrvs/messages/NetprPathCanonicalizeResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssrvs/messages/NetprPathCanonicalizeResponse.java
@@ -38,12 +38,10 @@ import com.rapid7.client.dcerpc.mssrvs.NetprPathType;
 public class NetprPathCanonicalizeResponse extends RequestResponse {
     private String canonicalizedPath;
     private int pathType;
-    private int returnValue;
 
-    public void unmarshal(final PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
         canonicalizedPath = readChars(packetIn);
         pathType = packetIn.readInt();
-        returnValue = packetIn.readInt();
     }
 
     public String getCanonicalizedPath() {
@@ -52,10 +50,6 @@ public class NetprPathCanonicalizeResponse extends RequestResponse {
 
     public NetprPathType getPathType() {
         return NetprPathType.getid(pathType);
-    }
-
-    public SystemErrorCode getReturnValue() {
-        return SystemErrorCode.getErrorCode(returnValue);
     }
 
     private String readChars(final PacketInput packetIn) throws IOException {

--- a/src/main/java/com/rapid7/client/dcerpc/mssrvs/messages/NetrShareEnumResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssrvs/messages/NetrShareEnumResponse.java
@@ -98,7 +98,6 @@ public class NetrShareEnumResponse extends RequestResponse {
     private List<NetShareInfo0> shares;
     private int shareCount;
     private Integer resumeHandle;
-    private int returnValue;
 
     public int getLevel() {
         return level;
@@ -116,12 +115,8 @@ public class NetrShareEnumResponse extends RequestResponse {
         return resumeHandle;
     }
 
-    public int getReturnValue() {
-        return returnValue;
-    }
-
     @Override
-    public void unmarshal(final PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
         shares = new LinkedList<>();
         level = packetIn.readInt();
         packetIn.readInt();
@@ -193,6 +188,5 @@ public class NetrShareEnumResponse extends RequestResponse {
 
         shareCount = packetIn.readInt();
         resumeHandle = packetIn.readIntRef();
-        returnValue = packetIn.readInt();
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/msvcctl/messages/RChangeServiceConfigWResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msvcctl/messages/RChangeServiceConfigWResponse.java
@@ -24,20 +24,14 @@ import com.rapid7.client.dcerpc.messages.RequestResponse;
 
 public class RChangeServiceConfigWResponse extends RequestResponse {
     private int tagId;
-    private int returnValue;
 
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         int tagIdRefId = packetIn.readReferentID();
         if (tagIdRefId != 0) tagId = packetIn.readInt();
-        returnValue = packetIn.readInt();
     }
 
     public int getTagId() {
         return tagId;
-    }
-
-    public int getReturnValue() {
-        return returnValue;
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/msvcctl/messages/RQueryServiceConfigWResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msvcctl/messages/RQueryServiceConfigWResponse.java
@@ -20,6 +20,7 @@ package com.rapid7.client.dcerpc.msvcctl.messages;
 
 import java.io.IOException;
 import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
 import com.rapid7.client.dcerpc.messages.RequestResponse;
 import com.rapid7.client.dcerpc.msvcctl.enums.ServiceError;
 import com.rapid7.client.dcerpc.msvcctl.enums.ServiceStartType;
@@ -29,13 +30,11 @@ import com.rapid7.client.dcerpc.msvcctl.objects.ServiceConfigInfo;
 public class RQueryServiceConfigWResponse extends RequestResponse {
     private ServiceConfigInfo serviceConfigInfo;
     private int bytesNeeded;
-    private int returnValue;
 
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         readQueryServiceConfg(packetIn);
         bytesNeeded = packetIn.readInt();
-        returnValue = packetIn.readInt();
     }
 
     private void readQueryServiceConfg(PacketInput packetIn) throws IOException {
@@ -65,9 +64,5 @@ public class RQueryServiceConfigWResponse extends RequestResponse {
 
     public ServiceConfigInfo getServiceConfigInfo() {
         return serviceConfigInfo;
-    }
-
-    public int getReturnValue() {
-        return returnValue;
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/msvcctl/messages/RQueryServiceStatusResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msvcctl/messages/RQueryServiceStatusResponse.java
@@ -28,11 +28,10 @@ import com.rapid7.client.dcerpc.msvcctl.objects.IServiceStatusInfo;
 import com.rapid7.client.dcerpc.msvcctl.objects.ServiceStatusInfo;
 
 public class RQueryServiceStatusResponse extends RequestResponse {
-    private int returnValue;
     private IServiceStatusInfo serviceStatusInfo;
 
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
         ServiceType serviceType = ServiceType.fromInt(packetIn.readInt());
         ServiceStatusType currentState = ServiceStatusType.fromInt(packetIn.readInt());
         ServicesAcceptedControls controlsAccepted = ServicesAcceptedControls.fromInt(packetIn.readInt());
@@ -41,14 +40,9 @@ public class RQueryServiceStatusResponse extends RequestResponse {
         int checkPoint = packetIn.readInt();
         int waitHint = packetIn.readInt();
         serviceStatusInfo = new ServiceStatusInfo(serviceType, currentState, controlsAccepted, win32ExitCode, serviceSpecificExitCode, checkPoint, waitHint);
-        returnValue = packetIn.readInt();
     }
 
     public IServiceStatusInfo getServiceStatusInfo() {
         return serviceStatusInfo;
-    }
-
-    public int getReturnValue() {
-        return returnValue;
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/objects/EmptyResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/EmptyResponse.java
@@ -23,14 +23,8 @@ import com.rapid7.client.dcerpc.io.PacketInput;
 import com.rapid7.client.dcerpc.messages.RequestResponse;
 
 public class EmptyResponse extends RequestResponse {
-    private int returnValue;
-
     @Override
-    public void unmarshal(PacketInput packetIn) throws IOException {
-        returnValue = packetIn.readInt();
-    }
-
-    public int getReturnValue() {
-        return returnValue;
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
+        // Empty
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/messages/Test_LsarQueryInformationPolicyResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/messages/Test_LsarQueryInformationPolicyResponse.java
@@ -33,6 +33,7 @@ import com.rapid7.client.dcerpc.mslsad.objects.PolicyInformationClass;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
@@ -58,11 +59,11 @@ public class Test_LsarQueryInformationPolicyResponse {
     public Object[][] data_unmarshal() {
         return new Object[][] {
                 // Reference: 1, POLICY_INFORMATION_CLASS: 2
-                {new LsarQueryInformationPolicyResponse.PolicyAuditEventsInformation(), "01000000 0200"},
+                {new LsarQueryInformationPolicyResponse.PolicyAuditEventsInformation(), "01000000 0200 00000000"},
                 // Reference: 1, POLICY_INFORMATION_CLASS: 3
-                {new LsarQueryInformationPolicyResponse.PolicyPrimaryDomainInformation(), "01000000 0300"},
+                {new LsarQueryInformationPolicyResponse.PolicyPrimaryDomainInformation(), "01000000 0300 00000000"},
                 // Reference: 1, POLICY_INFORMATION_CLASS: 5
-                {new LsarQueryInformationPolicyResponse.PolicyAccountDomainInformation(), "01000000 0500"}
+                {new LsarQueryInformationPolicyResponse.PolicyAccountDomainInformation(), "01000000 0500 00000000"}
         };
     }
 
@@ -78,9 +79,9 @@ public class Test_LsarQueryInformationPolicyResponse {
     @DataProvider
     public Object[][] data_unmarshall_Null() {
         return new Object[][] {
-                {new LsarQueryInformationPolicyResponse.PolicyAuditEventsInformation(), "00000000 0200"},
-                {new LsarQueryInformationPolicyResponse.PolicyPrimaryDomainInformation(), "00000000 0300"},
-                {new LsarQueryInformationPolicyResponse.PolicyAccountDomainInformation(), "00000000 0500"}
+                {new LsarQueryInformationPolicyResponse.PolicyAuditEventsInformation(), "00000000 0200 00000000"},
+                {new LsarQueryInformationPolicyResponse.PolicyPrimaryDomainInformation(), "00000000 0300 00000000"},
+                {new LsarQueryInformationPolicyResponse.PolicyAccountDomainInformation(), "00000000 0500 00000000"}
         };
     }
 
@@ -108,5 +109,6 @@ public class Test_LsarQueryInformationPolicyResponse {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = spy(new PacketInput(bin));
         response.unmarshal(in);
+        assertEquals(bin.available(), 0);
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/msrrp/Test_RegistryService.java
+++ b/src/test/java/com/rapid7/client/dcerpc/msrrp/Test_RegistryService.java
@@ -550,10 +550,10 @@ public class Test_RegistryService {
         when(hiveResponse.getReturnValue()).thenReturn(ERROR_SUCCESS.getErrorCode());
         when(keyResponse.getReturnValue()).thenReturn(ERROR_SUCCESS.getErrorCode());
         when(enumResponse1.getName()).thenReturn("subKey1");
-        when(enumResponse1.getLastWriteTime()).thenReturn(new FileTime(116444736000000000l));
+        when(enumResponse1.getLastWriteTime()).thenReturn(116444736000000000l);
         when(enumResponse1.getReturnValue()).thenReturn(ERROR_SUCCESS.getErrorCode());
         when(enumResponse2.getName()).thenReturn("subKey2");
-        when(enumResponse2.getLastWriteTime()).thenReturn(new FileTime(116444736000000000l));
+        when(enumResponse2.getLastWriteTime()).thenReturn(116444736000000000l);
         when(enumResponse2.getReturnValue()).thenReturn(ERROR_SUCCESS.getErrorCode());
         when(enumResponse3.getReturnValue()).thenReturn(ERROR_NO_MORE_ITEMS.getErrorCode());
 

--- a/src/test/java/com/rapid7/client/dcerpc/msrrp/messages/Test_BaseRegEnumKeyResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/msrrp/messages/Test_BaseRegEnumKeyResponse.java
@@ -71,7 +71,7 @@ public class Test_BaseRegEnumKeyResponse {
         response.fromHexString("180000020000020000010000000000000c000000420043004400300030003000300030003000300030000000040002000200feff08000200ff7f00000000000001000000000000000c00020026cd57b90de6d20100000000");
 
         assertEquals("BCD00000000", response.getName());
-        assertEquals(new FileTime(131420285765668134L), response.getLastWriteTime());
+        assertEquals(131420285765668134L, response.getLastWriteTime());
         assertEquals(0, response.getReturnValue());
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationAliasResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationAliasResponse.java
@@ -34,6 +34,7 @@ import com.rapid7.client.dcerpc.mssamr.objects.AliasInformationClass;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
@@ -57,7 +58,7 @@ public class Test_SamrQueryInformationAliasResponse {
     public Object[][] data_unmarshal() {
         return new Object[][] {
                 // Reference: 1, ALIAS_INFORMATION_CLASS: 1
-                {new SamrQueryInformationAliasResponse.AliasGeneralInformation(), "01000000 0100"}
+                {new SamrQueryInformationAliasResponse.AliasGeneralInformation(), "01000000 0100 01000000"}
         };
     }
 
@@ -67,13 +68,15 @@ public class Test_SamrQueryInformationAliasResponse {
         PacketInput in = spy(new PacketInput(bin));
         doReturn(null).when(in).readUnmarshallable(any(Unmarshallable.class));
         response.unmarshal(in);
+        assertEquals(bin.available(), 0);
         assertNotNull(response.getAliasInformation());
+        assertEquals(response.getReturnValue(), 1);
     }
 
     @DataProvider
     public Object[][] data_unmarshall_Null() {
         return new Object[][] {
-                {new SamrQueryInformationAliasResponse.AliasGeneralInformation(), "00000000 0100"}
+                {new SamrQueryInformationAliasResponse.AliasGeneralInformation(), "00000000 01000000"}
         };
     }
 
@@ -82,7 +85,9 @@ public class Test_SamrQueryInformationAliasResponse {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = spy(new PacketInput(bin));
         response.unmarshal(in);
+        assertEquals(bin.available(), 0);
         assertNull(response.getAliasInformation());
+        assertEquals(response.getReturnValue(), 1);
     }
 
     @DataProvider

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationDomain.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationDomain.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 import com.rapid7.client.dcerpc.io.PacketInput;
-import com.rapid7.client.dcerpc.mslsad.objects.DomainInformationClass;
 import com.rapid7.client.dcerpc.mssamr.objects.SAMPRDomainLockoutInfo;
 import com.rapid7.client.dcerpc.mssamr.objects.SAMPRDomainLogOffInfo;
 import com.rapid7.client.dcerpc.mssamr.objects.SAMPRDomainPasswordInfo;
@@ -33,7 +32,7 @@ public class Test_SamrQueryInformationDomain {
 
     @Test
     public void SamrQueryPasswordInformationDomain() throws IOException {
-        String hexString = "000002000100000000000000000000000000000040deffff000000000000000000000000";
+        String hexString = "000002000100000000000000000000000000000040deffff000000000000000001000000";
         SamrQueryInformationDomainResponse<SAMPRDomainPasswordInfo> response =
                 new SamrQueryInformationDomainResponse.DomainPasswordInformation();
         response.unmarshal(getPacketInput(hexString));
@@ -48,7 +47,7 @@ public class Test_SamrQueryInformationDomain {
 
     @Test
     public void SamrQueryLogOffInformationDomain() throws IOException {
-        String hexString = "0000020003000000000000000000008000000000";
+        String hexString = "0000020003000000000000000000008001000000";
         SamrQueryInformationDomainResponse<SAMPRDomainLogOffInfo>
                 response = new SamrQueryInformationDomainResponse.DomainLogOffInformation();
         response.unmarshal(getPacketInput(hexString));
@@ -56,11 +55,12 @@ public class Test_SamrQueryInformationDomain {
 
         // -9223372036854775808(never expire)
         assertEquals(-9223372036854775808L, logOffInfo.getForceLogoff());
+        assertEquals(response.getReturnValue(), 1);
     }
 
     @Test
     public void SamrQueryLockoutInformationDomain() throws IOException {
-        String hexString = "000002000c00000000cc1dcffbffffff00cc1dcffbffffff0000";
+        String hexString = "000002000c00000000cc1dcffbffffff00cc1dcffbffffff000001000000";
         SamrQueryInformationDomainResponse<SAMPRDomainLockoutInfo> response =
                 new SamrQueryInformationDomainResponse.DomainLockoutInformation();
         response.unmarshal(getPacketInput(hexString));
@@ -70,6 +70,7 @@ public class Test_SamrQueryInformationDomain {
         assertEquals(-18000000000L, lockout.getLockoutDuration());
         assertEquals(-18000000000L, lockout.getLockoutObservationWindow());
         assertEquals(0, lockout.getLockoutThreshold());
+        assertEquals(response.getReturnValue(), 1);
     }
 
     private PacketInput getPacketInput(final String hexString) {

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationGroupResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationGroupResponse.java
@@ -35,6 +35,7 @@ import com.rapid7.client.dcerpc.mssamr.objects.UserInformationClass;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
@@ -58,7 +59,7 @@ public class Test_SamrQueryInformationGroupResponse {
     public Object[][] data_unmarshal() {
         return new Object[][] {
                 // Reference: 1, GROUP_INFORMATION_CLASS: 1
-                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "01000000 0100"}
+                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "01000000 0100 01000000"}
         };
     }
 
@@ -68,13 +69,15 @@ public class Test_SamrQueryInformationGroupResponse {
         PacketInput in = spy(new PacketInput(bin));
         doReturn(null).when(in).readUnmarshallable(any(Unmarshallable.class));
         response.unmarshal(in);
+        assertEquals(bin.available(), 0);
         assertNotNull(response.getGroupInformation());
+        assertEquals(response.getReturnValue(), 1);
     }
 
     @DataProvider
     public Object[][] data_unmarshall_Null() {
         return new Object[][] {
-                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "00000000 0100"}
+                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "00000000 01000000"}
         };
     }
 
@@ -83,14 +86,16 @@ public class Test_SamrQueryInformationGroupResponse {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = spy(new PacketInput(bin));
         response.unmarshal(in);
+        assertEquals(bin.available(), 0);
         assertNull(response.getGroupInformation());
+        assertEquals(response.getReturnValue(), 1);
     }
 
     @DataProvider
     public Object[][] data_unmarshal_InvalidTag() {
         return new Object[][] {
                 // Reference: 1, POLICY_CLASS_INFORMATION: 3
-                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "01000000 FFFF"},
+                {new SamrQueryInformationGroupResponse.GroupGeneralInformation(), "01000000 FFFF 00000001"},
         };
     }
 

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationUserResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationUserResponse.java
@@ -34,6 +34,7 @@ import com.rapid7.client.dcerpc.mssamr.objects.UserInformationClass;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
@@ -57,7 +58,7 @@ public class Test_SamrQueryInformationUserResponse {
     public Object[][] data_unmarshal() {
         return new Object[][] {
                 // Reference: 1, USER_INFORMATION_CLASS: 21
-                {new SamrQueryInformationUserResponse.UserAllInformation(), "01000000 1500"}
+                {new SamrQueryInformationUserResponse.UserAllInformation(), "01000000 1500 01000000"}
         };
     }
 
@@ -67,13 +68,15 @@ public class Test_SamrQueryInformationUserResponse {
         PacketInput in = spy(new PacketInput(bin));
         doReturn(null).when(in).readUnmarshallable(any(Unmarshallable.class));
         response.unmarshal(in);
+        assertEquals(bin.available(), 0);
         assertNotNull(response.getUserInformation());
+        assertEquals(response.getReturnValue(), 1);
     }
 
     @DataProvider
     public Object[][] data_unmarshall_Null() {
         return new Object[][] {
-                {new SamrQueryInformationUserResponse.UserAllInformation(), "00000000 1500"}
+                {new SamrQueryInformationUserResponse.UserAllInformation(), "00000000 01000000"}
         };
     }
 
@@ -82,7 +85,9 @@ public class Test_SamrQueryInformationUserResponse {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = spy(new PacketInput(bin));
         response.unmarshal(in);
+        assertEquals(bin.available(), 0);
         assertNull(response.getUserInformation());
+        assertEquals(response.getReturnValue(), 1);
     }
 
     @DataProvider
@@ -100,5 +105,6 @@ public class Test_SamrQueryInformationUserResponse {
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = spy(new PacketInput(bin));
         response.unmarshal(in);
+        assertEquals(bin.available(), 0);
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQuerySecurityObjectResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQuerySecurityObjectResponse.java
@@ -47,29 +47,31 @@ public class Test_SamrQuerySecurityObjectResponse {
                 "02000000" +
                 // SecurityDescriptor: Length: 2 Reference: 2
                 "02000000 00000200" +
-                // SecurityDescriptor: MaximumCount: 3 SecurityDescriptor: {1, 2}
-                "02000000 01 02";
+                // SecurityDescriptor: MaximumCount: 3 SecurityDescriptor: {1, 2}, ReturnValue: 1
+                "02000000 01 02 01000000";
 
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = new PacketInput(bin);
 
         SamrQuerySecurityObjectResponse response = new SamrQuerySecurityObjectResponse();
         response.unmarshal(in);
-
+        assertEquals(bin.available(), 0);
         assertNotNull(response.getSecurityDescriptor());
         assertEquals(response.getSecurityDescriptor().getSecurityDescriptor(), new byte[]{1, 2});
+        assertEquals(response.getReturnValue(), 1);
     }
 
     @Test
     public void test_unmarshal_null() throws IOException {
-        // Reference: 0
-        String hex = "00000000";
+        // Reference: 0, ReturnValue: 1
+        String hex = "00000000 01000000";
         ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
         PacketInput in = new PacketInput(bin);
 
         SamrQuerySecurityObjectResponse response = new SamrQuerySecurityObjectResponse();
         response.unmarshal(in);
-
+        assertEquals(bin.available(), 0);
         assertNull(response.getSecurityDescriptor());
+        assertEquals(response.getReturnValue(), 1);
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssrvs/Test_NetPrPathCanonicalize.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssrvs/Test_NetPrPathCanonicalize.java
@@ -40,7 +40,7 @@ public class Test_NetPrPathCanonicalize {
 
 
         assertEquals("C:\\Something", response.getCanonicalizedPath());
-        assertEquals(SystemErrorCode.ERROR_SUCCESS, response.getReturnValue());
+        assertEquals(SystemErrorCode.ERROR_SUCCESS.getErrorCode(), response.getReturnValue());
         assertEquals(NetprPathType.ITYPE_PATH_ABSD, response.getPathType());
     }
 


### PR DESCRIPTION
Return values (SystemErrorCode) are always present for all request responses.
- unmarshalRequest has been added as an abstract method. All implementors must use this to unmarshall their request specific response data
- unmarshal calls unmarshalRequest first, and then always parses the return value
- Convenience methods have been added to get the well known SystemErrorCode from the return value