### PR TITLE
Refactoring SamrQueryInformationDomain and SamrQueryInformationDomain2

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
@@ -199,11 +199,9 @@ public class SecurityAccountManagerService {
         return transport.call(request).getDomainInformation();
     }
 
-    public SamrQueryInformationDomainResponse<SAMPRDomainLockoutInfo> getDomainLockoutInfo(
-        final DomainHandle DomainHandle) throws IOException {
-        SamrQueryInformationDomain2Request request = new SamrQueryInformationDomain2Request(DomainHandle,
-            DomainInformationClass.DOMAIN_LOCKOUT_INFORMATION);
-        return transport.call(request);
+    public SAMPRDomainLockoutInfo getDomainLockoutInfo(final DomainHandle domainHandle) throws IOException {
+        SamrQueryInformationDomain2Request.DomainLockoutInfo request = new SamrQueryInformationDomain2Request.DomainLockoutInfo(domainHandle);
+        return transport.call(request).getDomainInformation();
     }
 
     /**

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationDomain2Request.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationDomain2Request.java
@@ -20,6 +20,7 @@ package com.rapid7.client.dcerpc.mssamr.messages;
 
 import java.io.IOException;
 import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
 import com.rapid7.client.dcerpc.messages.RequestCall;
 import com.rapid7.client.dcerpc.mslsad.objects.DomainInformationClass;
 import com.rapid7.client.dcerpc.mssamr.objects.DomainHandle;
@@ -52,27 +53,43 @@ import com.rapid7.client.dcerpc.mssamr.objects.SAMPRDomainLockoutInfo;
  * </pre>
  * </blockquote>
  */
-public class SamrQueryInformationDomain2Request
-        extends RequestCall<SamrQueryInformationDomainResponse<SAMPRDomainLockoutInfo>> {
-    public final static short OP_NUM = 46;
-    private final DomainHandle handle;
-    private final DomainInformationClass infoLevel;
+public abstract class SamrQueryInformationDomain2Request<T extends Unmarshallable>
+        extends RequestCall<SamrQueryInformationDomainResponse<T>> {
 
-    public SamrQueryInformationDomain2Request(final DomainHandle handle, final DomainInformationClass infoLevel) {
+    public final static short OP_NUM = 46;
+
+    private final DomainHandle domainHandle;
+
+    public SamrQueryInformationDomain2Request(final DomainHandle domainHandle) {
         super(OP_NUM);
-        this.handle = handle;
-        this.infoLevel = infoLevel;
+        this.domainHandle = domainHandle;
     }
+
+    public DomainHandle getDomainHandle() {
+        return this.domainHandle;
+    }
+
+    public abstract DomainInformationClass getDomainInformationClass();
 
     @Override
     public void marshal(PacketOutput packetOut) throws IOException {
-        packetOut.write(handle.getBytes());
-        packetOut.writeShort(infoLevel.getInfoLevel());
+        packetOut.write(getDomainHandle().getBytes());
+        packetOut.writeShort(getDomainInformationClass().getInfoLevel());
     }
 
-    @Override
-    public SamrQueryInformationDomainResponse<SAMPRDomainLockoutInfo> getResponseObject() {
-        return new SamrQueryInformationDomainResponse<SAMPRDomainLockoutInfo>(new SAMPRDomainLockoutInfo(), infoLevel);
-    }
+    public static class DomainLockoutInfo extends SamrQueryInformationDomain2Request<SAMPRDomainLockoutInfo> {
+        public DomainLockoutInfo(DomainHandle handle) {
+            super(handle);
+        }
 
+        @Override
+        public DomainInformationClass getDomainInformationClass() {
+            return DomainInformationClass.DOMAIN_LOCKOUT_INFORMATION;
+        }
+
+        @Override
+        public SamrQueryInformationDomainResponse.DomainLockoutInformation getResponseObject() {
+            return new SamrQueryInformationDomainResponse.DomainLockoutInformation();
+        }
+    }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationDomainRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrQueryInformationDomainRequest.java
@@ -55,50 +55,57 @@ import com.rapid7.client.dcerpc.mssamr.objects.SAMPRDomainPasswordInfo;
  */
 public abstract class SamrQueryInformationDomainRequest<T extends Unmarshallable>
         extends RequestCall<SamrQueryInformationDomainResponse<T>> {
+
     public final static short OP_NUM = 8;
-    private final DomainHandle handle;
-    private final DomainInformationClass infoLevel;
 
-    public SamrQueryInformationDomainRequest(final DomainHandle handle, final DomainInformationClass infoLevel) {
+    private final DomainHandle domainHandle;
+
+    public SamrQueryInformationDomainRequest(final DomainHandle domainHandle) {
         super(OP_NUM);
-        this.handle = handle;
-        this.infoLevel = infoLevel;
+        this.domainHandle = domainHandle;
     }
 
-    abstract T newDomainInformation();
-
-    @Override
-    public SamrQueryInformationDomainResponse<T> getResponseObject() {
-        return new SamrQueryInformationDomainResponse<T>(newDomainInformation(), infoLevel);
-
+    public DomainHandle getDomainHandle() {
+        return domainHandle;
     }
+
+    public abstract DomainInformationClass getDomainInformationClass();
 
     @Override
     public void marshal(PacketOutput packetOut) throws IOException {
-        packetOut.write(handle.getBytes());
-        packetOut.writeShort(infoLevel.getInfoLevel());
+        packetOut.write(getDomainHandle().getBytes());
+        packetOut.writeShort(getDomainInformationClass().getInfoLevel());
     }
 
     public static class DomainPasswordInformation extends SamrQueryInformationDomainRequest<SAMPRDomainPasswordInfo> {
         public DomainPasswordInformation(final DomainHandle handle) {
-            super(handle, DomainInformationClass.DOMAIN_PASSWORD_INFORMATION);
+            super(handle);
         }
 
         @Override
-        SAMPRDomainPasswordInfo newDomainInformation() {
-            return new SAMPRDomainPasswordInfo();
+        public DomainInformationClass getDomainInformationClass() {
+            return DomainInformationClass.DOMAIN_PASSWORD_INFORMATION;
+        }
+
+        @Override
+        public SamrQueryInformationDomainResponse.DomainPasswordInformation getResponseObject() {
+            return new SamrQueryInformationDomainResponse.DomainPasswordInformation();
         }
     }
 
     public static class DomainLogOffInformation extends SamrQueryInformationDomainRequest<SAMPRDomainLogOffInfo> {
         public DomainLogOffInformation(final DomainHandle handle) {
-            super(handle, DomainInformationClass.DOMAIN_LOGOFF_INFORMATION);
+            super(handle);
         }
 
         @Override
-        SAMPRDomainLogOffInfo newDomainInformation() {
-            return new SAMPRDomainLogOffInfo();
+        public DomainInformationClass getDomainInformationClass() {
+            return DomainInformationClass.DOMAIN_LOGOFF_INFORMATION;
+        }
+
+        @Override
+        public SamrQueryInformationDomainResponse.DomainLogOffInformation getResponseObject() {
+            return new SamrQueryInformationDomainResponse.DomainLogOffInformation();
         }
     }
-
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationDomain.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrQueryInformationDomain.java
@@ -34,10 +34,10 @@ public class Test_SamrQueryInformationDomain {
     @Test
     public void SamrQueryPasswordInformationDomain() throws IOException {
         String hexString = "000002000100000000000000000000000000000040deffff000000000000000000000000";
-        SAMPRDomainPasswordInfo passInfo = new SAMPRDomainPasswordInfo();
-        SamrQueryInformationDomainResponse<SAMPRDomainPasswordInfo> response = new SamrQueryInformationDomainResponse<>(
-            passInfo, DomainInformationClass.DOMAIN_PASSWORD_INFORMATION);
+        SamrQueryInformationDomainResponse<SAMPRDomainPasswordInfo> response =
+                new SamrQueryInformationDomainResponse.DomainPasswordInformation();
         response.unmarshal(getPacketInput(hexString));
+        SAMPRDomainPasswordInfo passInfo = response.getDomainInformation();
 
         assertEquals(-37108517437440L, passInfo.getMaximumPasswordAge());
         assertEquals(0, passInfo.getMinimumPasswordAge());
@@ -49,10 +49,10 @@ public class Test_SamrQueryInformationDomain {
     @Test
     public void SamrQueryLogOffInformationDomain() throws IOException {
         String hexString = "0000020003000000000000000000008000000000";
-        SAMPRDomainLogOffInfo logOffInfo = new SAMPRDomainLogOffInfo();
-        SamrQueryInformationDomainResponse<SAMPRDomainLogOffInfo> response = new SamrQueryInformationDomainResponse<>(
-            logOffInfo, DomainInformationClass.DOMAIN_LOGOFF_INFORMATION);
+        SamrQueryInformationDomainResponse<SAMPRDomainLogOffInfo>
+                response = new SamrQueryInformationDomainResponse.DomainLogOffInformation();
         response.unmarshal(getPacketInput(hexString));
+        SAMPRDomainLogOffInfo logOffInfo = response.getDomainInformation();
 
         // -9223372036854775808(never expire)
         assertEquals(-9223372036854775808L, logOffInfo.getForceLogoff());
@@ -61,10 +61,10 @@ public class Test_SamrQueryInformationDomain {
     @Test
     public void SamrQueryLockoutInformationDomain() throws IOException {
         String hexString = "000002000c00000000cc1dcffbffffff00cc1dcffbffffff0000";
-        SAMPRDomainLockoutInfo lockout = new SAMPRDomainLockoutInfo();
-        SamrQueryInformationDomainResponse<SAMPRDomainLockoutInfo> response = new SamrQueryInformationDomainResponse<>(
-            lockout, DomainInformationClass.DOMAIN_LOCKOUT_INFORMATION);
+        SamrQueryInformationDomainResponse<SAMPRDomainLockoutInfo> response =
+                new SamrQueryInformationDomainResponse.DomainLockoutInformation();
         response.unmarshal(getPacketInput(hexString));
+        SAMPRDomainLockoutInfo lockout = response.getDomainInformation();
 
         // 1800 seconds
         assertEquals(-18000000000L, lockout.getLockoutDuration());


### PR DESCRIPTION
- Duplicating logic in SamrQueryInformationDomain into SamrQueryInformationDomain2. They are separate requests and it's cleaner to handle them separately
- Using the same approach to information request/response as done in SamrQueryInformationGroup and other similar structures