### PR TITLE
Supporting SamrLookupNamesInDomain

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
@@ -47,6 +47,8 @@ import com.rapid7.client.dcerpc.mssamr.messages.SamrEnumerateResponse;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrEnumerateUsersInDomainRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrGetGroupsForUserRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrGetGroupsForUserResponse;
+import com.rapid7.client.dcerpc.mssamr.messages.SamrLookupNamesInDomainRequest;
+import com.rapid7.client.dcerpc.mssamr.messages.SamrLookupNamesInDomainResponse;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenAliasRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenAliasResponse;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenDomainRequest;
@@ -82,6 +84,7 @@ import com.rapid7.client.dcerpc.mssamr.objects.ServerHandle;
 import com.rapid7.client.dcerpc.mssamr.objects.UserHandle;
 import com.rapid7.client.dcerpc.mssamr.objects.UserInfo;
 import com.rapid7.client.dcerpc.objects.ContextHandle;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 import com.rapid7.client.dcerpc.transport.RPCTransport;
 
 public class SecurityAccountManagerService {
@@ -345,6 +348,18 @@ public class SecurityAccountManagerService {
             throw new RPCException("GetGroupsForUser", response.getReturnValue());
 
         return response.getGroupMembership();
+    }
+
+    public SamrLookupNamesInDomainResponse getNamesInDomain(DomainHandle domainHandle, String ... names)
+            throws IOException {
+        if (names == null)
+            names = new String[0];
+        RPCUnicodeString.NonNullTerminated[] inNames = new RPCUnicodeString.NonNullTerminated[names.length];
+        for (int i = 0; i < names.length; i++) {
+            inNames[i] = RPCUnicodeString.NonNullTerminated.of(names[i]);
+        }
+        SamrLookupNamesInDomainRequest request = new SamrLookupNamesInDomainRequest(domainHandle, inNames);
+        return transport.call(request);
     }
 
     /**

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupNamesInDomainRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupNamesInDomainRequest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.messages.RequestCall;
+import com.rapid7.client.dcerpc.mssamr.objects.DomainHandle;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
+
+/**
+ * <a href="https://msdn.microsoft.com/en-us/library/cc245712.aspx">SamrLookupNamesInDomain</a>
+ * <blockquote><pre>The SamrLookupNamesInDomain method translates a set of account names into a set of RIDs.
+ *
+ *      long SamrLookupNamesInDomain(
+ *          [in] SAMPR_HANDLE DomainHandle,
+ *          [in, range(0,1000)] unsigned long Count,
+ *          [in, size_is(1000), length_is(Count)] RPC_UNICODE_STRING Names[*],
+ *          [out] PSAMPR_ULONG_ARRAY RelativeIds,
+ *          [out] PSAMPR_ULONG_ARRAY Use
+ *      );
+ *
+ *  DomainHandle: An RPC context handle, as specified in section 2.2.3.2, representing a domain object.
+ *
+ *  Count: The number of elements in Names. The maximum value of 1,000 is chosen to limit the amount of memory that the client can force the server to allocate.
+ *
+ *  Names: An array of strings that are to be mapped to RIDs.
+ *
+ *  RelativeIds: An array of RIDs of accounts that correspond to the elements in Names.
+ *
+ *  Use: An array of SID_NAME_USE enumeration values that describe the type of account for each entry in RelativeIds.
+ *
+ *  This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject the use of context handles created by a method of a different RPC interface than this one, as specified in [MS-RPCE] section 3.
+ *  </pre></blockquote>
+ *
+ */
+public class SamrLookupNamesInDomainRequest extends RequestCall<SamrLookupNamesInDomainResponse> {
+    public static final short OP_NUM = 17;
+
+    // <NDR: fixed array> [in] SAMPR_HANDLE DomainHandle
+    private final DomainHandle domainHandle;
+    // <NDR: unsigned long> [in, range(0,1000)] unsigned long Count
+    // Derived from names
+    // <NDR: conformant varying array> [in, size_is(1000), length_is(Count)] RPC_UNICODE_STRING Names[*]
+    private final RPCUnicodeString.NonNullTerminated[] names;
+
+    public SamrLookupNamesInDomainRequest(final DomainHandle domainHandle, final RPCUnicodeString.NonNullTerminated[] names) {
+        super(OP_NUM);
+        if (domainHandle == null) {
+            throw new IllegalArgumentException("domainHandle must not be null");
+        }
+        if (names == null) {
+            throw new IllegalArgumentException("names must not be null");
+        } else if (names.length > 1000) {
+            throw new IllegalArgumentException(String.format(
+                    "names must not contain more than 1000 elements, got: %d", names.length));
+        }
+        this.domainHandle = domainHandle;
+        this.names = names;
+    }
+
+    public DomainHandle getDomainHandle() {
+        return domainHandle;
+    }
+
+    public RPCUnicodeString.NonNullTerminated[] getNames() {
+        return names;
+    }
+
+    @Override
+    public SamrLookupNamesInDomainResponse getResponseObject() {
+        return new SamrLookupNamesInDomainResponse();
+    }
+
+    @Override
+    public void marshal(PacketOutput packetOut) throws IOException {
+        // [in] SAMPR_HANDLE DomainHandle
+        // Alignment: 1 - Already aligned
+        packetOut.writeMarshallable(this.domainHandle);
+        // <NDR: unsigned long> [in, range(0,1000)] unsigned long Count
+        // Alignment: 4 - Already aligned, wrote 20 bytes above
+        packetOut.writeInt(this.names.length);
+        // MaximumCount: <NDR: conformant varying array> [in, size_is(1000), length_is(Count)] RPC_UNICODE_STRING Names[*]
+        // Alignment: 4 - Already aligned
+        packetOut.writeInt(1000);
+        // Offset: <NDR: conformant varying array> [in, size_is(1000), length_is(Count)] RPC_UNICODE_STRING Names[*]
+        // Alignment: 4 - Already aligned
+        packetOut.writeInt(0);
+        // ActualLength: <NDR: conformant varying array> [in, size_is(1000), length_is(Count)] RPC_UNICODE_STRING Names[*]
+        // Alignment: 4 - Already aligned
+        packetOut.writeInt(this.names.length);
+        // Entities: <NDR: conformant varying array> [in, size_is(1000), length_is(Count)] RPC_UNICODE_STRING Names[*]
+        for (RPCUnicodeString.NonNullTerminated name : this.names) {
+            name.marshalPreamble(packetOut);
+        }
+        for (RPCUnicodeString.NonNullTerminated name : this.names) {
+            name.marshalEntity(packetOut);
+        }
+        for (RPCUnicodeString.NonNullTerminated name : this.names) {
+            name.marshalDeferrals(packetOut);
+        }
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupNamesInDomainResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupNamesInDomainResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.messages.RequestResponse;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRULongArray;
+
+public class SamrLookupNamesInDomainResponse extends RequestResponse {
+    // [out] PSAMPR_ULONG_ARRAY RelativeIds
+    private SAMPRULongArray relativeIds;
+    // [out] PSAMPR_ULONG_ARRAY Use
+    private SAMPRULongArray use;
+
+
+    public SAMPRULongArray getRelativeIds() {
+        return relativeIds;
+    }
+
+    public SAMPRULongArray getUse() {
+        return use;
+    }
+
+    @Override
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
+        this.relativeIds = new SAMPRULongArray();
+        packetIn.readUnmarshallable(this.relativeIds);
+        this.use = new SAMPRULongArray();
+        packetIn.readUnmarshallable(this.use);
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRULongArray.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRULongArray.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+import java.io.IOException;
+import java.rmi.UnmarshalException;
+import java.util.Arrays;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+
+/**
+ * <b>Alignment: 4</b>
+ * <a href="https://msdn.microsoft.com/en-us/library/cc245825.aspx">SAMPR_ULONG_ARRAY</a>
+ * <blockquote><pre>
+ *      typedef struct _SAMPR_ULONG_ARRAY {
+ *          unsigned long Count;
+ *          [size_is(Count)] unsigned long * Element;
+ *      } SAMPR_ULONG_ARRAY, *PSAMPR_ULONG_ARRAY;</pre></blockquote>
+ */
+public class SAMPRULongArray implements Unmarshallable {
+    private long[] array;
+
+    public long[] getArray() {
+        return array;
+    }
+
+    public void setArray(long[] array) {
+        this.array = array;
+    }
+
+    @Override
+    public void unmarshalPreamble(PacketInput in) throws IOException {
+        // No preamble
+    }
+
+    @Override
+    public void unmarshalEntity(PacketInput in) throws IOException {
+        // Structure Alignment: 4
+        in.align(Alignment.FOUR);
+        // unsigned long Count;
+        final int count = readIndex("Count", in);
+        if (in.readReferentID() != 0) {
+            array = new long[count];
+        } else {
+            array = null;
+        }
+    }
+
+    @Override
+    public void unmarshalDeferrals(PacketInput in) throws IOException {
+        if (array != null) {
+            // MaximumCount: [size_is(Count)] unsigned long * Element;
+            in.align(Alignment.FOUR);
+            in.fullySkipBytes(4);
+            // Elements: [size_is(Count)] unsigned long * Element;
+            for (int i = 0; i < array.length; i++) {
+                array[i] = in.readUnsignedInt();
+            }
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(getArray());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (! (obj instanceof SAMPRULongArray)) {
+            return false;
+        }
+        return Arrays.equals(getArray(), ((SAMPRULongArray) obj).getArray());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("SAMPR_ULONG_ARRAY{size(Element):%s",
+                (this.array == null ? "null" : this.array.length));
+    }
+
+    private int readIndex(String name, PacketInput in) throws IOException {
+        final long ret = in.readUnsignedInt();
+        // Don't allow array length or index values bigger than signed int
+        if (ret > Integer.MAX_VALUE) {
+            throw new UnmarshalException(String.format("%s %d > %d", name, ret, Integer.MAX_VALUE));
+        }
+        return (int) ret;
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/objects/SIDNameUse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/SIDNameUse.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.objects;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <blockquote><pre>The SID_NAME_USE enumeration specifies the type of account that a SID references.
+ *      typedef  enum _SID_NAME_USE
+ *      {
+ *          SidTypeUser = 1,
+ *          SidTypeGroup,
+ *          SidTypeDomain,
+ *          SidTypeAlias,
+ *          SidTypeWellKnownGroup,
+ *          SidTypeDeletedAccount,
+ *          SidTypeInvalid,
+ *          SidTypeUnknown,
+ *          SidTypeComputer,
+ *          SidTypeLabel
+ *      } SID_NAME_USE,
+ *      *PSID_NAME_USE;
+ * SidTypeUser: Indicates a user object.
+ * SidTypeGroup: Indicates a group object.
+ * SidTypeDomain: Indicates a domain object.
+ * SidTypeAlias: Indicates an alias object.
+ * SidTypeWellKnownGroup: Indicates an object whose SID is invariant.
+ * SidTypeDeletedAccount: Indicates an object that has been deleted.
+ * SidTypeInvalid: This member is not used.
+ * SidTypeUnknown: Indicates that the type of object could not be determined. For example, no object with that SID exists.
+ * SidTypeComputer: This member is not used.
+ * SidTypeLabel: This member is not used.</pre></blockquote>
+ */
+public enum SIDNameUse {
+    SID_TYPE_USER((short) 1),
+    SID_TYPE_GROUP((short) 2),
+    SID_TYPE_DOMAIN((short) 3),
+    SID_TYPE_ALIAS((short) 4),
+    SID_TYPE_WELL_KNOWN_GROUP((short) 5),
+    SID_TYPE_DELETED_ACCOUNT((short) 6),
+    SID_TYPE_INVALID((short) 7),
+    SID_TYPE_UNKNOWN((short) 8),
+    SID_TYPE_COMPUTER((short) 9),
+    SID_TYPE_LABEL((short) 10);
+
+    private final short value;
+
+    SIDNameUse(final short value) {
+        this.value = value;
+    }
+
+    public short getValue() {
+        return value;
+    }
+
+    private static final Map<Short, SIDNameUse> VALUE_MAP = new HashMap<>();
+    static {
+        for (SIDNameUse sidNameUse : SIDNameUse.values()) {
+            VALUE_MAP.put(sidNameUse.getValue(), sidNameUse);
+        }
+    }
+
+    public static SIDNameUse fromValue(final short value) {
+        return VALUE_MAP.get(value);
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrLookupNamesInDomainRequest.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrLookupNamesInDomainRequest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.Test;
+
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.mssamr.objects.DomainHandle;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+
+public class Test_SamrLookupNamesInDomainRequest {
+    @Test
+    public void test_getters() {
+        DomainHandle domainHandle = new DomainHandle();
+        RPCUnicodeString.NonNullTerminated[] names = new RPCUnicodeString.NonNullTerminated[2];
+
+        SamrLookupNamesInDomainRequest obj = new SamrLookupNamesInDomainRequest(domainHandle, names);
+        assertSame(obj.getDomainHandle(), domainHandle);
+        assertSame(obj.getNames(), names);
+        assertNotNull(obj.getResponseObject());
+        assertEquals(obj.getOpNum(), SamrLookupNamesInDomainRequest.OP_NUM);
+    }
+
+    @Test(expectedExceptions = {IllegalArgumentException.class},
+            expectedExceptionsMessageRegExp = "domainHandle must not be null")
+    public void test_DomainHandleNull() {
+        new SamrLookupNamesInDomainRequest(null, new RPCUnicodeString.NonNullTerminated[2]);
+    }
+
+    @Test(expectedExceptions = {IllegalArgumentException.class},
+            expectedExceptionsMessageRegExp = "names must not be null")
+    public void test_NamesNull() {
+        new SamrLookupNamesInDomainRequest(new DomainHandle(), null);
+    }
+
+    @Test(expectedExceptions = {IllegalArgumentException.class},
+            expectedExceptionsMessageRegExp = "names must not contain more than 1000 elements, got: 1001")
+    public void test_NamesTooLong() {
+        new SamrLookupNamesInDomainRequest(new DomainHandle(), new RPCUnicodeString.NonNullTerminated[1001]);
+    }
+
+    @Test
+    public void test_marshall() throws IOException {
+        String expectHex =
+                // DomainHandle
+                "0102030405060708090a0b0c0d0e0f1011121314" +
+                // Count: 3
+                "03000000" +
+                // MaximumCount: 1000
+                "e8030000" +
+                // Offset: 0
+                "00000000" +
+                // Actual Count: 3
+                "03000000" +
+                // RPCUnicodeString.NonNullTerminated entity: {Length:26,MaximumLength:26,Reference:Non-zero}
+                "1a001a0000000200" +
+                // RPCUnicodeString.NonNullTerminated entity: {Length:0,MaximumLength:0,Reference:0}
+                "0000000000000000" +
+                // RPCUnicodeString.NonNullTerminated entity: {Length:14,MaximumLength:14,Reference:Non-zero}
+                "0e000e0004000200" +
+                // RPCUnicodeString.NonNullTerminated deferral: {MaximumCount:13,Offset:0,ActualCount:13,Value:Administrator}
+                "0d000000000000000d000000410064006d0069006e006900730074007200610074006f007200" +
+                // Alignment: 2b
+                "0000" +
+                // RPCUnicodeString.NonNullTerminated deferral: {MaximumCount:7,Offset:0,ActualCount:7,Value:Test123}
+                "0700000000000000070000005400650073007400310032003300";
+        DomainHandle domainHandle = new DomainHandle();
+        domainHandle.setBytes(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20});
+        RPCUnicodeString.NonNullTerminated[] names = new RPCUnicodeString.NonNullTerminated[] {
+            RPCUnicodeString.NonNullTerminated.of("Administrator"),
+            RPCUnicodeString.NonNullTerminated.of(null),
+            RPCUnicodeString.NonNullTerminated.of("Test123")
+        };
+
+        SamrLookupNamesInDomainRequest obj = new SamrLookupNamesInDomainRequest(domainHandle, names);
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        PacketOutput out = new PacketOutput(bout);
+        obj.marshal(out);
+        assertEquals(Hex.toHexString(bout.toByteArray()), expectHex);
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrLookupNamesInDomainResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrLookupNamesInDomainResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.Test;
+
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.mssamr.objects.SAMPRULongArray;
+
+import static org.testng.Assert.assertEquals;
+
+public class Test_SamrLookupNamesInDomainResponse {
+    @Test
+    public void test_getters() {
+        SamrLookupNamesInDomainResponse obj = new SamrLookupNamesInDomainResponse();
+        assertEquals(obj.getRelativeIds(), null);
+        assertEquals(obj.getUse(), null);
+        assertEquals(obj.getReturnValue(), 0);
+    }
+
+
+    @Test
+    public void test_unmarshal() throws IOException {
+        String hex =
+                // RelativeIds: {Count: 3, Reference: 1}
+                "03000000 01000000" +
+                // RelativeIds: {MaximumCount: 2, Array: {1, 2147483648L, 3},
+                "02000000 01000000 00000080 03000000" +
+                // Use: {Count: 3, Reference: 2}
+                "03000000 02000000" +
+                // Use: {MaximumCount: 2, Array: {4, 5, 6},
+                "02000000 04000000 05000000 06000000" +
+                // Return Value
+                "01000000";
+
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        SamrLookupNamesInDomainResponse obj = new SamrLookupNamesInDomainResponse();
+        obj.unmarshal(in);
+
+        assertEquals(bin.available(), 0);
+        SAMPRULongArray relativeIds = new SAMPRULongArray();
+        relativeIds.setArray(new long[]{1, 2147483648L, 3});
+        assertEquals(obj.getRelativeIds(), relativeIds);
+        SAMPRULongArray use = new SAMPRULongArray();
+        use.setArray(new long[]{4, 5, 6});
+        assertEquals(obj.getUse(), use);
+        assertEquals(obj.getReturnValue(), 1);
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRULongArray.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRULongArray.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.objects;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.rapid7.client.dcerpc.io.PacketInput;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertSame;
+
+public class Test_SAMPRULongArray {
+    @Test
+    public void test_getters() {
+        SAMPRULongArray obj = new SAMPRULongArray();
+        assertEquals(obj.getArray(), null);
+    }
+
+    @Test
+    public void test_setters() {
+        SAMPRULongArray obj = new SAMPRULongArray();
+        long[] array = new long[]{1, 2, 3};
+        obj.setArray(array);
+        assertSame(obj.getArray(), array);
+    }
+
+    @Test
+    public void test_unmarshalPreamble() throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(new byte[0]);
+        PacketInput in = new PacketInput(bin);
+        SAMPRULongArray obj = new SAMPRULongArray();
+        obj.unmarshalPreamble(in);
+        assertEquals(obj.getArray(), null);
+        assertEquals(bin.available(), 0);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshalEntity() {
+        return new Object[][] {
+                // Count: 1, Reference: 0
+                {"01000000 00000000", 0, null},
+                // Count: 25, Reference: 1
+                {"19000000 01000000", 0, new long[25]},
+                // Alignments
+                {"FFFFFFFF 19000000 01000000", 1, new long[25]},
+                {"FFFFFFFF 19000000 01000000", 2, new long[25]},
+                {"FFFFFFFF 19000000 01000000", 3, new long[25]}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshalEntity")
+    public void test_unmarshalEntity(String hex, int mark, long[] expectArray) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        in.fullySkipBytes(mark);
+        SAMPRULongArray obj = new SAMPRULongArray();
+        obj.unmarshalEntity(in);
+        assertEquals(obj.getArray(), expectArray);
+        assertEquals(bin.available(), 0);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshalDeferrals() {
+        return new Object[][] {
+                // null
+                {"", 0, null, null},
+                // MaximumCount: 2, Array: {1, 2147483648L, 2}
+                {"02000000 01000000 00000080 02000000", 0, new long[3], new long[]{1, 2147483648L, 2}},
+                // ALignments
+                {"FFFFFFFF 02000000 01000000 00000080 02000000", 1, new long[3], new long[]{1, 2147483648L, 2}},
+                {"FFFFFFFF 02000000 01000000 00000080 02000000", 2, new long[3], new long[]{1, 2147483648L, 2}},
+                {"FFFFFFFF 02000000 01000000 00000080 02000000", 3, new long[3], new long[]{1, 2147483648L, 2}}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshalDeferrals")
+    public void test_unmarshalDeferrals(String hex, int mark, long[] array, long[] expectArray) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+        in.fullySkipBytes(mark);
+        SAMPRULongArray obj = new SAMPRULongArray();
+        obj.setArray(array);
+        obj.unmarshalDeferrals(in);
+        assertEquals(obj.getArray(), expectArray);
+        assertEquals(bin.available(), 0);
+    }
+
+    @Test
+    public void test_hashCode() {
+        SAMPRULongArray obj1 = new SAMPRULongArray();
+        SAMPRULongArray obj2 = new SAMPRULongArray();
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+        obj1.setArray(new long[]{1, 2, 3});
+        assertNotEquals(obj1.hashCode(), obj2.hashCode());
+        obj2.setArray(new long[]{1, 2, 3});
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+    }
+
+    @Test
+    public void test_equals() {
+        SAMPRULongArray obj1 = new SAMPRULongArray();
+        assertEquals(obj1, obj1);
+        assertNotEquals(obj1, null);
+        SAMPRULongArray obj2 = new SAMPRULongArray();
+        assertEquals(obj1, obj2);
+        obj1.setArray(new long[]{1, 2, 3});
+        assertNotEquals(obj1, obj2);
+        obj2.setArray(new long[]{1, 2, 3});
+        assertEquals(obj1, obj2);
+    }
+
+    @Test
+    public void test_toString_default() {
+        assertEquals(new SAMPRULongArray().toString(), "SAMPR_ULONG_ARRAY{size(Element):null");
+    }
+
+    @Test
+    public void test_toString() {
+        SAMPRULongArray obj = new SAMPRULongArray();
+        obj.setArray(new long[]{1, 2, 3});
+        assertEquals(obj.toString(), "SAMPR_ULONG_ARRAY{size(Element):3");
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/objects/Test_SIDNameUse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/objects/Test_SIDNameUse.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.objects;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+public class Test_SIDNameUse {
+
+    @DataProvider
+    public Object[][] data_pairs() {
+        return new Object[][] {
+                {SIDNameUse.SID_TYPE_USER, (short) 1},
+                {SIDNameUse.SID_TYPE_GROUP, (short) 2},
+                {SIDNameUse.SID_TYPE_DOMAIN, (short) 3},
+                {SIDNameUse.SID_TYPE_ALIAS, (short) 4},
+                {SIDNameUse.SID_TYPE_WELL_KNOWN_GROUP, (short) 5},
+                {SIDNameUse.SID_TYPE_DELETED_ACCOUNT, (short) 6},
+                {SIDNameUse.SID_TYPE_INVALID, (short) 7},
+                {SIDNameUse.SID_TYPE_UNKNOWN, (short) 8},
+                {SIDNameUse.SID_TYPE_COMPUTER, (short) 9},
+                {SIDNameUse.SID_TYPE_LABEL, (short) 10}
+        };
+    }
+
+    @Test(dataProvider = "data_pairs")
+    public void test_getValue(SIDNameUse use, short expected) {
+        assertEquals(use.getValue(), expected);
+    }
+
+    @Test(dataProvider = "data_pairs")
+    public void test_fromValue(SIDNameUse expected, short value) {
+        assertSame(SIDNameUse.fromValue(value), expected);
+    }
+
+    @Test
+    public void test_fromValue_unknown() {
+        assertNull(SIDNameUse.fromValue((short) 255));
+    }
+
+}


### PR DESCRIPTION
* Adds `com.rapid7.client.dcerpc.mssamr.messages.SamrLookupNamesInDomainRequest`/`Response` (SamrLookupNamesInDomain)
* Adds `com.rapid7.client.dcerpc.mssamr.objects.SAMPRULongArray` (SAMPR_ULONG_ARRAY). Represents array of unsigned longs
* Adds `com.rapid7.client.dcerpc.mssamr.SecurityAccountManagerService.getNamesInDomain` convenience method. Accepts varargs of strings instead of RPCUnicodeString
* Adds `com.rapid7.client.dcerpc.objects.SIDNameUse`. SID_NAME_USE entries in `SamrLookupNamesInDomainResponse.getUse()` are not mapped to the enum itself. This allows the client to inspect the raw values should any issues arise. Use of