### PR TITLE
Adds support for SamrLookupDomainInSamServer

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
@@ -47,6 +47,7 @@ import com.rapid7.client.dcerpc.mssamr.messages.SamrEnumerateResponse;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrEnumerateUsersInDomainRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrGetGroupsForUserRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrGetGroupsForUserResponse;
+import com.rapid7.client.dcerpc.mssamr.messages.SamrLookupDomainInSamServerRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenAliasRequest;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenAliasResponse;
 import com.rapid7.client.dcerpc.mssamr.messages.SamrOpenDomainRequest;
@@ -82,6 +83,8 @@ import com.rapid7.client.dcerpc.mssamr.objects.ServerHandle;
 import com.rapid7.client.dcerpc.mssamr.objects.UserHandle;
 import com.rapid7.client.dcerpc.mssamr.objects.UserInfo;
 import com.rapid7.client.dcerpc.objects.ContextHandle;
+import com.rapid7.client.dcerpc.objects.RPCSID;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 import com.rapid7.client.dcerpc.transport.RPCTransport;
 
 public class SecurityAccountManagerService {
@@ -345,6 +348,12 @@ public class SecurityAccountManagerService {
             throw new RPCException("GetGroupsForUser", response.getReturnValue());
 
         return response.getGroupMembership();
+    }
+
+    public RPCSID getSIDForDomain(ServerHandle serverHandle, String domainName) throws IOException {
+        SamrLookupDomainInSamServerRequest request = new SamrLookupDomainInSamServerRequest(serverHandle,
+                RPCUnicodeString.NonNullTerminated.of(domainName));
+        return transport.call(request).getDomainId();
     }
 
     /**

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupDomainInSamServerRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupDomainInSamServerRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.messages.RequestCall;
+import com.rapid7.client.dcerpc.mssamr.objects.ServerHandle;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
+
+/**
+ * <a href="https://msdn.microsoft.com/en-us/library/cc245711.aspx">SamrLookupDomainInSamServer</a>
+ * <blockquote><pre>The SamrLookupDomainInSamServer method obtains the SID of a domain object, given the object's name.
+ *      long SamrLookupDomainInSamServer(
+ *          [in] SAMPR_HANDLE ServerHandle,
+ *          [in] PRPC_UNICODE_STRING Name,
+ *          [out] PRPC_SID* DomainId
+ *      );
+ *  ServerHandle: An RPC context handle, as specified in section 2.2.3.2, representing a server object.
+ *  Name: A UTF-16 encoded string.
+ *  DomainId: A SID value of a domain that corresponds to the Name passed in. The match MUST be exact (no wildcard characters are permitted). See message processing later in this section for more details.
+ *
+ *  This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject the use of context handles created by a method of a different RPC interface than this one, as specified in [MS-RPCE] section 3.</pre></blockquote>
+ */
+public class SamrLookupDomainInSamServerRequest extends RequestCall<SamrLookupDomainInSamServerResponse> {
+    public static final short OP_NUM = 5;
+
+    // <NDR: fixed array> [in] SAMPR_HANDLE ServerHandle
+    private final ServerHandle serverHandle;
+    // <NDR: pointer[struct]> [in] PRPC_UNICODE_STRING Name,
+    private final RPCUnicodeString.NonNullTerminated name;
+
+    public SamrLookupDomainInSamServerRequest(final ServerHandle serverHandle, RPCUnicodeString.NonNullTerminated name) {
+        super(OP_NUM);
+        this.serverHandle = serverHandle;
+        this.name = name;
+    }
+
+    public ServerHandle getServerHandle() {
+        return serverHandle;
+    }
+
+    public RPCUnicodeString.NonNullTerminated getName() {
+        return name;
+    }
+
+    @Override
+    public SamrLookupDomainInSamServerResponse getResponseObject() {
+        return new SamrLookupDomainInSamServerResponse();
+    }
+
+    @Override
+    public void marshal(PacketOutput packetOut) throws IOException {
+        // <NDR: fixed array> [in] SAMPR_HANDLE ServerHandle
+        packetOut.writeMarshallable(getServerHandle());
+        // <NDR: pointer[struct]> [in] PRPC_UNICODE_STRING Name
+        packetOut.writeMarshallable(getName());
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupDomainInSamServerRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupDomainInSamServerRequest.java
@@ -46,7 +46,7 @@ public class SamrLookupDomainInSamServerRequest extends RequestCall<SamrLookupDo
 
     // <NDR: fixed array> [in] SAMPR_HANDLE ServerHandle
     private final ServerHandle serverHandle;
-    // <NDR: pointer[struct]> [in] PRPC_UNICODE_STRING Name,
+    // <NDR: struct> [in] PRPC_UNICODE_STRING Name,
     private final RPCUnicodeString.NonNullTerminated name;
 
     public SamrLookupDomainInSamServerRequest(final ServerHandle serverHandle, RPCUnicodeString.NonNullTerminated name) {
@@ -72,7 +72,7 @@ public class SamrLookupDomainInSamServerRequest extends RequestCall<SamrLookupDo
     public void marshal(PacketOutput packetOut) throws IOException {
         // <NDR: fixed array> [in] SAMPR_HANDLE ServerHandle
         packetOut.writeMarshallable(getServerHandle());
-        // <NDR: pointer[struct]> [in] PRPC_UNICODE_STRING Name
+        // <NDR: struct> [in] PRPC_UNICODE_STRING Name
         packetOut.writeMarshallable(getName());
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupDomainInSamServerResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupDomainInSamServerResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.messages.RequestResponse;
+import com.rapid7.client.dcerpc.objects.RPCSID;
+
+public class SamrLookupDomainInSamServerResponse extends RequestResponse {
+    // [out] PRPC_SID* DomainId
+    private RPCSID domainId;
+
+    public RPCSID getDomainId() {
+        return domainId;
+    }
+
+    @Override
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
+        if (packetIn.readReferentID() != 0) {
+            this.domainId = new RPCSID();
+            packetIn.readUnmarshallable(this.domainId);
+        } else {
+            this.domainId = null;
+        }
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupDomainInSamServerResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrLookupDomainInSamServerResponse.java
@@ -27,7 +27,7 @@ import com.rapid7.client.dcerpc.messages.RequestResponse;
 import com.rapid7.client.dcerpc.objects.RPCSID;
 
 public class SamrLookupDomainInSamServerResponse extends RequestResponse {
-    // [out] PRPC_SID* DomainId
+    // <NDR: pointer[struct]> [out] PRPC_SID* DomainId
     private RPCSID domainId;
 
     public RPCSID getDomainId() {

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrLookupDomainInSamServerRequest.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrLookupDomainInSamServerRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.Test;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.mssamr.objects.ServerHandle;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+
+public class Test_SamrLookupDomainInSamServerRequest {
+
+    @Test
+    public void test_getters() {
+        ServerHandle serverHandle = new ServerHandle();
+        RPCUnicodeString.NonNullTerminated name = new RPCUnicodeString.NonNullTerminated();
+        SamrLookupDomainInSamServerRequest obj = new SamrLookupDomainInSamServerRequest(serverHandle, name);
+        assertSame(obj.getServerHandle(), serverHandle);
+        assertSame(obj.getName(), name);
+        assertNotNull(obj.getResponseObject());
+    }
+
+    @Test
+    public void test_marshal() throws IOException {
+        String expectHex =
+                // ServerHandle: {1...20}
+                "0102030405060708090a0b0c0d0e0f1011121314" +
+                // RPCUnicodeString.NonNullTerminated entity: {Length:14,MaximumLength:14,Reference:Non-zero}
+                "0e000e0000000200" +
+                // RPCUnicodeString.NonNullTerminated deferral: {MaximumCount:7,Offset:0,ActualCount:7,Value:test123}
+                "0700000000000000070000007400650073007400310032003300";
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        PacketOutput out = new PacketOutput(bout);
+
+        ServerHandle serverHandle = new ServerHandle();
+        serverHandle.setBytes(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20});
+        RPCUnicodeString.NonNullTerminated name = RPCUnicodeString.NonNullTerminated.of("test123");
+        SamrLookupDomainInSamServerRequest obj = new SamrLookupDomainInSamServerRequest(serverHandle, name);
+        obj.marshal(out);
+        assertEquals(Hex.toHexString(bout.toByteArray()), expectHex);
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrLookupDomainInSamServerResponse.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/messages/Test_SamrLookupDomainInSamServerResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.bouncycastle.util.encoders.Hex;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.objects.RPCSID;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class Test_SamrLookupDomainInSamServerResponse {
+
+    @Test
+    public void test_getters() {
+        SamrLookupDomainInSamServerResponse obj = new SamrLookupDomainInSamServerResponse();
+        assertNull(obj.getDomainId());
+        assertEquals(obj.getReturnValue(), 0);
+    }
+
+    @DataProvider
+    public Object[][] data_unmarshal() {
+        RPCSID domainId = new RPCSID();
+        domainId.setRevision((char) 25);
+        domainId.setIdentifierAuthority(new byte[]{1, 2, 3, 4, 5, 6});
+        domainId.setSubAuthority(new long[]{5, 2684354560L});
+
+        return new Object[][] {
+                // Reference: 0, ReturnValue: 1
+                {"00000000 01000000", null},
+                // Reference: 1 DomainId: {MaximumCount: 0, Revision:25,SubAuthorityCount:2,IdentifierAuthority:{1...6},SubAuthority:{5, 2684354560}, ReturnValue; 1
+                {"01000000 00000000190201020304050605000000000000a0 01000000", domainId}
+        };
+    }
+
+    @Test(dataProvider = "data_unmarshal")
+    public void test_unmarshal(String hex, RPCSID expectDomainId) throws IOException {
+        ByteArrayInputStream bin = new ByteArrayInputStream(Hex.decode(hex));
+        PacketInput in = new PacketInput(bin);
+
+        SamrLookupDomainInSamServerResponse obj = new SamrLookupDomainInSamServerResponse();
+        obj.unmarshal(in);
+
+        assertEquals(bin.available(), 0);
+        assertEquals(obj.getDomainId(), expectDomainId);
+        assertEquals(obj.getReturnValue(), 1);
+    }
+}


### PR DESCRIPTION
* Adds `com.rapid7.client.dcerpc.mssamr.messages.SamrLookupDomainInSamServerRequest`/`Response` (SamrLookupDomainInSamServer)
* Adds `com.rapid7.client.dcerpc.mssamr.SecurityAccountManagerService.getSIDForDomain` convenience method. Accepts a string instead of RPCUnicodeString
* Full test coverage