### PR TITLE
 Corrects marshalling errors in LsarLookupNames and LsarLookupSIDs 

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
@@ -189,7 +189,7 @@ public class LocalSecurityAuthorityService extends Service {
     }
 
     /**
-     * Look up {@link SID}s for the given names. Uses {@link LSAPLookupLevel#LsapLookupWksta} as a lookup level.
+     * Look up {@link SID}s for the given names. Uses {@link LSAPLookupLevel#LSAP_LOOKUP_WKSTA} as a lookup level.
      * @param policyHandle A valid policy handle obtained from {@link LocalSecurityAuthorityService#openPolicyHandle()}.
      * @param names Array of names to lookup {@link SID}s for.
      * @return An array of {@link SID}s. Each entry index in this list corresponds to the same entry index in
@@ -198,7 +198,7 @@ public class LocalSecurityAuthorityService extends Service {
      * returns an unsuccessful response.
      */
     public SID[] lookupNames(final PolicyHandle policyHandle, String... names) throws IOException {
-        return lookupNames(policyHandle, LSAPLookupLevel.LsapLookupWksta, names);
+        return lookupNames(policyHandle, LSAPLookupLevel.LSAP_LOOKUP_WKSTA, names);
     }
 
     /**
@@ -242,7 +242,7 @@ public class LocalSecurityAuthorityService extends Service {
     }
 
     /**
-     * Look up names for the given {@link SID}s. Uses {@link LSAPLookupLevel#LsapLookupWksta} as a lookup level.
+     * Look up names for the given {@link SID}s. Uses {@link LSAPLookupLevel#LSAP_LOOKUP_WKSTA} as a lookup level.
      * @param policyHandle A valid policy handle obtained from {@link LocalSecurityAuthorityService#openPolicyHandle()}.
      * @param sids Array of {@link SID}s to lookup
      * @return An array of names. Each entry index in this list corresponds to the same entry index in
@@ -251,7 +251,7 @@ public class LocalSecurityAuthorityService extends Service {
      * returns an unsuccessful response.
      */
     public String[] lookupSIDs(final PolicyHandle policyHandle, SID... sids) throws IOException {
-        return lookupSIDs(policyHandle, LSAPLookupLevel.LsapLookupWksta, sids);
+        return lookupSIDs(policyHandle, LSAPLookupLevel.LSAP_LOOKUP_WKSTA, sids);
     }
 
     /**

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
@@ -8,11 +8,11 @@
  * * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *
- * * Redistributions in binary form must reproduce the above copyright
+ * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
  *
- * * Neither the name of the copyright holder nor the names of its contributors
+ * Neither the name of the copyright holder nor the names of its contributors
  * may be used to endorse or promote products derived from this software
  * without specific prior written permission.
  */
@@ -198,12 +198,13 @@ public class LocalSecurityAuthorityService extends Service {
     public SID[] lookupNames(final PolicyHandle policyHandle, String... names) throws IOException {
         if (names == null)
             names = new String[0];
-        final LsarLookupNamesRequest request = new LsarLookupNamesRequest(parseHandle(policyHandle), names);
+        final LsarLookupNamesRequest request =
+                new LsarLookupNamesRequest(parseHandle(policyHandle), parseNonNullTerminatedStrings(names));
         final LsarLookupNamesResponse response = callExpect(request, "LsarLookupNames",
                 SystemErrorCode.ERROR_SUCCESS,
                 SystemErrorCode.STATUS_SOME_NOT_MAPPED);
-        final LSAPRTranslatedSID[] translatedSIDs = response.getLsaprTranslatedSIDs().getLsaprTranslatedSIDArray();
-        final LSAPRTrustInformation[] domainArray = response.getLsaprReferencedDomainList().getLsaprTrustInformations();
+        final LSAPRTranslatedSID[] translatedSIDs = response.getTranslatedSIDs().getSIDs();
+        final LSAPRTrustInformation[] domainArray = response.getReferencedDomains().getDomains();
         // Create DTO SIDs
         final SID[] sids = new SID[translatedSIDs.length];
         for (int i = 0; i < translatedSIDs.length; i++) {
@@ -240,9 +241,8 @@ public class LocalSecurityAuthorityService extends Service {
         final LsarLookupSIDsRequest request = new LsarLookupSIDsRequest(parseHandle(policyHandle), parseSIDs(sids));
         final LsarLookupSIDsResponse lsarLookupSIDsResponse = callExpect(request, "LsarLookupSIDs",
                 SystemErrorCode.ERROR_SUCCESS, SystemErrorCode.STATUS_SOME_NOT_MAPPED);
-
-        LSAPRTranslatedName[] nameArray = lsarLookupSIDsResponse.getLsaprTranslatedNames().getlsaprTranslatedNameArray();
-        String[] mappedNames = new String[nameArray.length];
+        final LSAPRTranslatedName[] nameArray = lsarLookupSIDsResponse.getTranslatedNames().getNames();
+        final String[] mappedNames = new String[nameArray.length];
         for (int i = 0; i < nameArray.length; i++) {
             mappedNames[i] = nameArray[i].getName().getValue();
         }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/dto/LSAPLookupLevel.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/dto/LSAPLookupLevel.java
@@ -125,7 +125,7 @@ public enum LSAPLookupLevel {
      * domains</a> for the domain to which this machine is joined.
      * </p>
      */
-    LsapLookupWksta,
+    LSAP_LOOKUP_WKSTA,
     /**
      * <p>
      * <strong>LsapLookupPDC:</strong> SIDs MUST be searched in the
@@ -163,7 +163,7 @@ public enum LSAPLookupLevel {
      * is joined.
      * </p>
      */
-    LsapLookupPDC,
+    LSAP_LOOKUP_PDC,
     /**
      * <p>
      * <strong>LsapLookupTDL:</strong> SIDs MUST be searched in the
@@ -178,7 +178,7 @@ public enum LSAPLookupLevel {
      * for the domain to which this machine is joined.
      * </p>
      */
-    LsapLookupTDL,
+    LSAP_LOOKUP_TDL,
     /**
      * <p>
      * <strong>LsapLookupGC:</strong> SIDs MUST be searched in the
@@ -191,7 +191,7 @@ public enum LSAPLookupLevel {
      * View of the forest of the domain to which this machine is joined.
      * </p>
      */
-    LsapLookupGC,
+    LSAP_LOOKUP_GC,
     /**
      * <p>
      * <strong>LsapLookupXForestReferral:</strong> SIDs MUST be
@@ -206,7 +206,7 @@ public enum LSAPLookupLevel {
      * joined.
      * </p>
      */
-    LsapLookupXForestReferral,
+    LSAP_LOOKUP_XFOREST_REFERRAL,
     /**
      * <p>
      * <strong>LsapLookupXForestResolve:</strong> SIDs MUST be
@@ -219,7 +219,7 @@ public enum LSAPLookupLevel {
      * View of the forest of the domain to which this machine is joined.
      * </p>
      */
-    LsapLookupXForestResolve,
+    LSAP_LOOKUP_XFOREST_RESOLVE,
     /**
      * <p>
      * <strong>LsapLookupRODCReferralToFullDC:</strong> SIDs MUST be
@@ -242,7 +242,7 @@ public enum LSAPLookupLevel {
      * is joined.
      * </p>
      */
-    LsapLookupRODCReferralToFullDC;
+    LSAP_LOOKUP_RODC_REFERRAL_TO_FULL_DC;
 
     public short getValue() {
         return (short) (ordinal() + 1);

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupNamesRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupNamesRequest.java
@@ -100,13 +100,13 @@ public class LsarLookupNamesRequest extends RequestCall<LsarLookupNamesResponse>
     private final static short OP_NUM = 14;
     private final static int LSA_LOOKUP_NAMES_ALL = 0x1;
 
-    private final String[] names;
     private final byte[] policyHandle;
+    private final RPCUnicodeString.NonNullTerminated[] names;
 
-    public LsarLookupNamesRequest(final byte[] policyHandle, final String[] names) {
+    public LsarLookupNamesRequest(final byte[] policyHandle, final RPCUnicodeString.NonNullTerminated[] names) {
         super(OP_NUM);
-        this.names = names;
         this.policyHandle = policyHandle;
+        this.names = names;
     }
 
     @Override
@@ -115,37 +115,39 @@ public class LsarLookupNamesRequest extends RequestCall<LsarLookupNamesResponse>
     }
 
     @Override
-    public void marshal(final PacketOutput packetOut)
-        throws IOException
-    {
-        packetOut.write(policyHandle);
-        packetOut.writeInt(names.length);
+    public void marshal(final PacketOutput packetOut) throws IOException {
+        // <NDR: fixed array> [in] LSAPR_HANDLE PolicyHandle
+        // Alignment: 1 - Already aligned
+        packetOut.write(this.policyHandle);
+        // <NDR: unsigned long> [in, range(0,1000)] unsigned long Count,
+        // Alignment; 4 - Already aligned, wrote 20 bytes above
+        packetOut.writeInt(this.names.length);
+        // <NDR: unsigned long> [in, size_is(Count)] PRPC_UNICODE_STRING Names
         writeNames(packetOut);
-        packetOut.align(Alignment.FOUR); // Names is variable length; align for SID
-
         //TODO: Write as packetOut.writeMarshalable(new LSAPRTranslatedSIDs())
+        // <NDR: struct> [in, out] PLSAPR_TRANSLATED_SIDS TranslatedSids
+        packetOut.align(Alignment.FOUR); // Names is variable length; align for SID
         packetOut.writeInt(0); //count for SID
         packetOut.writeNull(); // SID
-
+        // <NDR: short> [in] LSAP_LOOKUP_LEVEL LookupLevel,
         packetOut.writeInt(LSA_LOOKUP_NAMES_ALL);
+        // <NDR: unsigned long> [in, out] unsigned long* MappedCount
         packetOut.writeNull(); // Count (ignored on input)
     }
 
-    private void writeNames(final PacketOutput packetOut)
-        throws IOException
-    {
+    private void writeNames(final PacketOutput packetOut) throws IOException {
+        // MaximumCount: [in, size_is(Count)] PRPC_UNICODE_STRING Names
+        // Alignment: 4 - Already aligned
         packetOut.writeInt(names.length);
-
-        RPCUnicodeString[] rpcNames = new RPCUnicodeString[names.length];
-        for (int i = 0; i < rpcNames.length; i++){
-            rpcNames[i] = RPCUnicodeString.NonNullTerminated.of(names[i]);
-            rpcNames[i].marshalPreamble(packetOut);
+        // Entries: [in, size_is(Count)] PRPC_UNICODE_STRING Names
+        for (RPCUnicodeString.NonNullTerminated name : names) {
+            name.marshalPreamble(packetOut);
         }
-        for (RPCUnicodeString rpcName: rpcNames){
-            rpcName.marshalEntity(packetOut);
+        for (RPCUnicodeString.NonNullTerminated name : names) {
+            name.marshalEntity(packetOut);
         }
-        for (RPCUnicodeString rpcName: rpcNames){
-            rpcName.marshalDeferrals(packetOut);
+        for (RPCUnicodeString.NonNullTerminated name : names) {
+            name.marshalDeferrals(packetOut);
         }
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupNamesResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupNamesResponse.java
@@ -19,6 +19,7 @@
 package com.rapid7.client.dcerpc.mslsad.messages;
 
 import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
 import com.rapid7.client.dcerpc.messages.RequestResponse;
 import com.rapid7.client.dcerpc.mslsad.objects.LSAPRReferencedDomainList;
 import com.rapid7.client.dcerpc.mslsad.objects.LSAPRTranslatedSIDs;
@@ -51,42 +52,37 @@ import java.io.IOException;
  */
 
 public class LsarLookupNamesResponse extends RequestResponse {
-    private LSAPRReferencedDomainList lsaprReferencedDomainList;
-    private LSAPRTranslatedSIDs lsaprTranslatedSIDs;
+    // <NDR: pointer[struct]> [out] PLSAPR_REFERENCED_DOMAIN_LIST* ReferencedDomains
+    private LSAPRReferencedDomainList referencedDomains;
+    // <NDR: struct> [in, out] PLSAPR_TRANSLATED_SIDS TranslatedSids
+    private LSAPRTranslatedSIDs translatedSIDs;
+    // <NDR: unsigned long> [in, out] unsigned long* MappedCount
+    // Ignored
 
     @Override
-    public void unmarshalResponse(final PacketInput packetIn)
-            throws IOException {
-
-        //Top level parameters
-        //1. Referenced Domain List pointer
-        if (packetIn.readReferentID() != 0) //LsaprReferencedDomainList is a pointer
-        {
-            lsaprReferencedDomainList = new LSAPRReferencedDomainList();
-            packetIn.readUnmarshallable(lsaprReferencedDomainList);
-        } else { lsaprReferencedDomainList = null; }
-
-        //2. Translated Sids
-        lsaprTranslatedSIDs = new LSAPRTranslatedSIDs();
-        packetIn.readUnmarshallable(lsaprTranslatedSIDs);
-
-        //3. Mapped Count
-        packetIn.readInt();
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
+        // <NDR: pointer[struct]> [out] PLSAPR_REFERENCED_DOMAIN_LIST* ReferencedDomains
+        // Alignment: 4 - Already aligned
+        if (packetIn.readReferentID() != 0) { //LsaprReferencedDomainList is a pointer
+            referencedDomains = new LSAPRReferencedDomainList();
+            packetIn.readUnmarshallable(referencedDomains);
+        }
+        else {
+            referencedDomains = null;
+        }
+        // <NDR: struct> [in, out] PLSAPR_TRANSLATED_SIDS TranslatedSids
+        translatedSIDs = new LSAPRTranslatedSIDs();
+        packetIn.readUnmarshallable(translatedSIDs);
+        // <NDR: unsigned long> [in, out] unsigned long* MappedCount
+        packetIn.align(Alignment.FOUR);
+        packetIn.fullySkipBytes(4);
     }
 
-    public LSAPRReferencedDomainList getLsaprReferencedDomainList() {
-        return lsaprReferencedDomainList;
+    public LSAPRReferencedDomainList getReferencedDomains() {
+        return referencedDomains;
     }
 
-    public void setLsaprReferencedDomainList(LSAPRReferencedDomainList lsaprReferencedDomainList) {
-        this.lsaprReferencedDomainList = lsaprReferencedDomainList;
-    }
-
-    public LSAPRTranslatedSIDs getLsaprTranslatedSIDs() {
-        return lsaprTranslatedSIDs;
-    }
-
-    public void setLsaprTranslatedSIDs(LSAPRTranslatedSIDs lsaprTranslatedSIDs) {
-        this.lsaprTranslatedSIDs = lsaprTranslatedSIDs;
+    public LSAPRTranslatedSIDs getTranslatedSIDs() {
+        return translatedSIDs;
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupSIDsResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/messages/LsarLookupSIDsResponse.java
@@ -31,35 +31,40 @@ import java.io.IOException;
  */
 
 public class LsarLookupSIDsResponse extends RequestResponse {
+    // <NDR: pointer[struct]> [out] PLSAPR_REFERENCED_DOMAIN_LIST* ReferencedDomains
+    private LSAPRReferencedDomainList referencedDomains;
+    // <NDR: struct> [in, out] PLSAPR_TRANSLATED_NAMES TranslatedNames
+    private LSAPRTranslatedNames translatedNames;
+    // <NDR: unsigned long> [in, out] unsigned long* MappedCount
     private int mappedCount;
-    private LSAPRReferencedDomainList lsaprReferencedDomainList;
-    private LSAPRTranslatedNames lsaprTranslatedNames;
 
     @Override
-    public void unmarshalResponse(final PacketInput packetIn)
-            throws IOException {
-
+    public void unmarshalResponse(final PacketInput packetIn) throws IOException {
+        // <NDR: pointer[struct]> [out] PLSAPR_REFERENCED_DOMAIN_LIST* ReferencedDomains
+        // Alignment: 4 - Already aligned
         if (packetIn.readReferentID() != 0) {
-            lsaprReferencedDomainList = new LSAPRReferencedDomainList();
-            packetIn.readUnmarshallable(lsaprReferencedDomainList);
+            referencedDomains = new LSAPRReferencedDomainList();
+            packetIn.readUnmarshallable(referencedDomains);
+        } else {
+            referencedDomains = null;
         }
-
-        lsaprTranslatedNames = new LSAPRTranslatedNames();
-        packetIn.readUnmarshallable(lsaprTranslatedNames);
-        //Mapped Count
+        // <NDR: struct> [in, out] PLSAPR_TRANSLATED_NAMES TranslatedNames
+        translatedNames = new LSAPRTranslatedNames();
+        packetIn.readUnmarshallable(translatedNames);
+        // <NDR: unsigned long> [in, out] unsigned long* MappedCount
         packetIn.align(Alignment.FOUR);
         mappedCount = packetIn.readInt();
     }
 
+    public LSAPRReferencedDomainList getReferencedDomains() {
+        return referencedDomains;
+    }
+
+    public LSAPRTranslatedNames getTranslatedNames() {
+        return translatedNames;
+    }
+
     public int getMappedCount() {
         return mappedCount;
-    }
-
-    public LSAPRReferencedDomainList getLsaprReferencedDomainList() {
-        return lsaprReferencedDomainList;
-    }
-
-    public LSAPRTranslatedNames getLsaprTranslatedNames() {
-        return lsaprTranslatedNames;
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRTranslatedNames.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRTranslatedNames.java
@@ -56,65 +56,74 @@ import java.util.Arrays;
  */
 public class LSAPRTranslatedNames implements Unmarshallable
 {
-    private LSAPRTranslatedName[] lsaprTranslatedNameArray;
+    // <NDR: unsigned long> [range(0,20480)] unsigned long Entries;
+    // Only used in marshalling
+    // <NDR: pointer[conformant array]> [size_is(Entries)] PLSAPR_TRANSLATED_NAME Names;
+    private LSAPRTranslatedName[] names;
 
     @Override
     public void unmarshalPreamble(PacketInput in) throws IOException {
+        // No preamble
     }
 
     @Override
     public void unmarshalEntity(PacketInput in) throws IOException {
+        // Structure Alignment: 4
         in.align(Alignment.FOUR);
-        int entries = in.readInt();
-        if (in.readReferentID() != 0) {
-            lsaprTranslatedNameArray = new LSAPRTranslatedName[entries];
-        } else lsaprTranslatedNameArray = null;
+        // [range(0,20480)] unsigned long Entries;
+        // Alignment: 4 - Already aligned
+        final int entries = in.readInt();
+        // <NDR: pointer[conformant array]> [size_is(Entries)] PLSAPR_TRANSLATED_NAME Names;
+        // Alignment: 4 - Already aligned
+        if (in.readReferentID() != 0)
+            names = new LSAPRTranslatedName[entries];
+        else
+            names = null;
     }
 
     @Override
     public void unmarshalDeferrals(PacketInput in) throws IOException {
-        if (lsaprTranslatedNameArray != null) {
+        if (names != null) {
+            // MaximumCount: [size_is(Entries)] PLSAPR_TRANSLATED_NAME Names;
             in.align(Alignment.FOUR);
-            in.readInt(); //count
-            
-            for (int i = 0; i < lsaprTranslatedNameArray.length; i++){
+            in.fullySkipBytes(4);
+
+            // Entries: [size_is(Entries)] PLSAPR_TRANSLATED_NAME Names;
+            for (int i = 0; i < names.length; i++){
                 LSAPRTranslatedName lsaprTranslatedName = new LSAPRTranslatedName();
                 lsaprTranslatedName.unmarshalPreamble(in);
-                lsaprTranslatedNameArray[i] = lsaprTranslatedName;
+                names[i] = lsaprTranslatedName;
             }
-            for (LSAPRTranslatedName lsaprTranslatedName: lsaprTranslatedNameArray){
+            for (LSAPRTranslatedName lsaprTranslatedName: names){
                 lsaprTranslatedName.unmarshalEntity(in);
             }
-            for (LSAPRTranslatedName lsaprTranslatedName: lsaprTranslatedNameArray){
+            for (LSAPRTranslatedName lsaprTranslatedName: names){
                 lsaprTranslatedName.unmarshalDeferrals(in);
             }
         }
     }
 
-    public LSAPRTranslatedName[] getlsaprTranslatedNameArray() {
-        return lsaprTranslatedNameArray;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        LSAPRTranslatedNames that = (LSAPRTranslatedNames) o;
-
-        // Probably incorrect - comparing Object[] arrays with Arrays.equals
-        return Arrays.equals(lsaprTranslatedNameArray, that.lsaprTranslatedNameArray);
+    public LSAPRTranslatedName[] getNames() {
+        return names;
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(lsaprTranslatedNameArray);
+        return Arrays.hashCode(names);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (! (obj instanceof LSAPRTranslatedNames)) {
+            return false;
+        }
+        return Arrays.equals(this.names, ((LSAPRTranslatedNames) obj).names);
     }
 
     @Override
     public String toString() {
-        return "lsaprTranslatedNames{" +
-                "lsaprTranslatedNameArray=" + Arrays.toString(lsaprTranslatedNameArray) +
-                '}';
+        return String.format("LSAPR_TRANSLATED_NAMES{Names:%s}", Arrays.toString(names));
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRTranslatedSID.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRTranslatedSID.java
@@ -25,8 +25,10 @@ import com.rapid7.client.dcerpc.io.PacketInput;
 import com.rapid7.client.dcerpc.io.ndr.Alignment;
 import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
+ * <b>Alignment: 4</b>
  * Documentation from https://msdn.microsoft.com/en-us/library/cc234455.aspx
  *  <h1 class="title">2.2.14 LSA_TRANSLATED_SID</h1>
  *
@@ -62,27 +64,37 @@ import java.io.IOException;
  */
 public class LSAPRTranslatedSID implements Unmarshallable
 {
-    private int use;
+    // <NDR: short> SID_NAME_USE Use;
+    private short use;
+    // <NDR: unsigned long> unsigned long RelativeId;
     private long relativeId;
-    private long domainIndex;
+    // <NDR: long> long DomainIndex;
+    private int domainIndex;
 
     @Override
-    public void unmarshalPreamble(PacketInput in)
-        throws IOException {
+    public void unmarshalPreamble(PacketInput in) throws IOException {
+        // No preamble
     }
 
     @Override
-    public void unmarshalEntity(PacketInput in)
-        throws IOException {
+    public void unmarshalEntity(PacketInput in) throws IOException {
+        // Structure Alignment: 4
         in.align(Alignment.FOUR);
-        use = in.readInt();
-        relativeId = in.readUnsignedInt();
-        domainIndex = in.readUnsignedInt();
+        // <NDR: short> SID_NAME_USE Use;
+        // Alignment: 2 - Already aligned
+        this.use = in.readShort();
+        // <NDR: unsigned long> unsigned long RelativeId;
+        // Alignment: 4
+        in.fullySkipBytes(2);
+        this.relativeId = in.readUnsignedInt();
+        // <NDR: long> long DomainIndex;
+        // Alignment: 4 - Already aligned
+        domainIndex = in.readInt();
     }
 
     @Override
-    public void unmarshalDeferrals(PacketInput in)
-        throws IOException {
+    public void unmarshalDeferrals(PacketInput in) throws IOException {
+        // No deferrals
     }
 
     public int getUse() {
@@ -98,31 +110,27 @@ public class LSAPRTranslatedSID implements Unmarshallable
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (! (obj instanceof LSAPRTranslatedSID)) {
+            return false;
+        }
 
-        LSAPRTranslatedSID that = (LSAPRTranslatedSID) o;
-
-        if (use != that.use) return false;
-        if (relativeId != that.relativeId) return false;
-        return domainIndex == that.domainIndex;
+        final LSAPRTranslatedSID other = (LSAPRTranslatedSID) obj;
+        return Objects.equals(this.use, other.use)
+                && Objects.equals(this.relativeId, other.relativeId)
+                && Objects.equals(this.domainIndex, other.domainIndex);
     }
 
     @Override
     public int hashCode() {
-        int result = use;
-        result = 31 * result + (int) (relativeId ^ (relativeId >>> 32));
-        result = 31 * result + (int) (domainIndex ^ (domainIndex >>> 32));
-        return result;
+        return Objects.hash(this.use, this.relativeId, this.domainIndex);
     }
 
     @Override
     public String toString() {
-        return "LSAPRTranslatedSID{" +
-                "use=" + use +
-                ", relativeId=" + relativeId +
-                ", domainIndex=" + domainIndex +
-                '}';
+        return String.format("LSA_TRANSLATED_SID{Use:%d,RelativeId:%d,DomainIndex;%d}",
+                this.use, this.relativeId, this.domainIndex);
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRTrustInformation.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/objects/LSAPRTrustInformation.java
@@ -27,6 +27,7 @@ import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
 import com.rapid7.client.dcerpc.objects.RPCSID;
 import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  *  Documentation from https://msdn.microsoft.com/en-us/library/cc234259.aspx
@@ -57,31 +58,37 @@ import java.io.IOException;
  */
 public class LSAPRTrustInformation implements Unmarshallable
 {
+    // <NDR: struct> RPC_UNICODE_STRING Name;
     private RPCUnicodeString.NonNullTerminated name;
+    // <NDR: pointer[struct]> PRPC_SID Sid;
     private RPCSID sid;
 
     @Override
     public void unmarshalPreamble(PacketInput in) throws IOException {
+        // <NDR: struct> RPC_UNICODE_STRING Name;
         name = new RPCUnicodeString.NonNullTerminated();
         name.unmarshalPreamble(in);
     }
 
     @Override
     public void unmarshalEntity(PacketInput in) throws IOException {
+        // <NDR: struct> RPC_UNICODE_STRING Name;
         name.unmarshalEntity(in);
+        // <NDR: pointer[struct]> PRPC_SID Sid;
         in.align(Alignment.FOUR);
-
-        if (in.readReferentID() != 0){
+        if (in.readReferentID() != 0)
             sid = new RPCSID();
-        } else sid = null;
+        else
+            sid = null;
     }
 
     @Override
     public void unmarshalDeferrals(PacketInput in) throws IOException {
+        // <NDR: struct> RPC_UNICODE_STRING Name;
         name.unmarshalDeferrals(in);
-        if (sid != null){
+        // <NDR: struct> PRPC_SID Sid;
+        if (sid != null)
             in.readUnmarshallable(sid);
-        }
     }
 
     public RPCUnicodeString.NonNullTerminated getName() {
@@ -93,28 +100,25 @@ public class LSAPRTrustInformation implements Unmarshallable
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (! (obj instanceof LSAPRTrustInformation)) {
+            return false;
+        }
 
-        LSAPRTrustInformation that = (LSAPRTrustInformation) o;
-
-        if (name != null ? !name.equals(that.name) : that.name != null) return false;
-        return sid != null ? sid.equals(that.sid) : that.sid == null;
+        final LSAPRTrustInformation other = (LSAPRTrustInformation) obj;
+        return Objects.equals(this.name, other.name)
+                && Objects.equals(this.sid, other.sid);
     }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (sid != null ? sid.hashCode() : 0);
-        return result;
+        return Objects.hash(this.name, this.sid);
     }
 
     @Override
     public String toString() {
-        return "LSAPRTrustInformation{" +
-                "name=" + name +
-                ", sid=" + sid +
-                '}';
+        return String.format("LSAPR_TRUST_INFORMATION{Name:%s,Sid:%s}", this.name, this.sid);
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/service/Service.java
+++ b/src/main/java/com/rapid7/client/dcerpc/service/Service.java
@@ -29,6 +29,7 @@ import com.rapid7.client.dcerpc.messages.RequestResponse;
 import com.rapid7.client.dcerpc.mserref.SystemErrorCode;
 import com.rapid7.client.dcerpc.objects.RPCSID;
 import com.rapid7.client.dcerpc.dto.SID;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 import com.rapid7.client.dcerpc.transport.RPCTransport;
 
 public abstract class Service {
@@ -60,6 +61,16 @@ public abstract class Service {
             }
         }
         throw new RPCException(name, returnValue);
+    }
+
+    protected RPCUnicodeString.NonNullTerminated[] parseNonNullTerminatedStrings(String[] strings) {
+        if (strings == null)
+            return null;
+        final RPCUnicodeString.NonNullTerminated[] ret = new RPCUnicodeString.NonNullTerminated[strings.length];
+        for (int i = 0; i < strings.length; i++) {
+            ret[i] = RPCUnicodeString.NonNullTerminated.of(strings[i]);
+        }
+        return ret;
     }
 
     protected byte[] parseHandle(final ContextHandle handle) {

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/Test_LookupNames.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/Test_LookupNames.java
@@ -19,16 +19,13 @@
 
 package com.rapid7.client.dcerpc.mslsad;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.io.IOException;
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.testng.annotations.Test;
 import com.rapid7.client.dcerpc.dto.SID;
 import com.rapid7.client.dcerpc.mslsad.dto.LSAPLookupLevel;
 import com.rapid7.client.dcerpc.mslsad.dto.PolicyHandle;
@@ -41,8 +38,6 @@ import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 import com.rapid7.client.dcerpc.transport.RPCTransport;
 
 public class Test_LookupNames {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     @SuppressWarnings("unchecked")
     @Test
@@ -67,19 +62,19 @@ public class Test_LookupNames {
     @Test
     public void encodeLookupNamesRequest() throws IOException {
         final byte[] fakePolicyHandle = Hex.decode("000000008e3039708fdd9f488f9665426d0d9c57");
-        final RPCUnicodeString.NonNullTerminated[] names = {RPCUnicodeString.NonNullTerminated.of("Administrator")};
+        final RPCUnicodeString.NonNullTerminated[] names = {RPCUnicodeString.NonNullTerminated.of("Administrator"), RPCUnicodeString.NonNullTerminated.of("Administrator2")};
         final LsarLookupNamesRequest request = new LsarLookupNamesRequest(fakePolicyHandle, names, LSAPLookupLevel.LsapLookupWksta.getValue());
-        assertEquals(request.toHexString(), "000000008e3039708fdd9f488f9665426d0d9c5701000000010000001a001a00000002000d000000000000000d000000410064006d0069006e006900730074007200610074006f007200000000000000000000000100000000000000");
+        assertEquals(request.toHexString(), "000000008e3039708fdd9f488f9665426d0d9c5702000000020000001a001a00000002001c001c00040002000d000000000000000d000000410064006d0069006e006900730074007200610074006f00720000000e000000000000000e000000410064006d0069006e006900730074007200610074006f007200320000000000000000000100000000000000");
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void encodeLookupNamesRequest2() throws IOException {
         final byte[] fakePolicyHandle = Hex.decode("000000008e3039708fdd9f488f9665426d0d9c57");
-        final RPCUnicodeString.NonNullTerminated[] names = {RPCUnicodeString.NonNullTerminated.of("Administrator")};
+        final RPCUnicodeString.NonNullTerminated[] names = {RPCUnicodeString.NonNullTerminated.of("Administrator"), RPCUnicodeString.NonNullTerminated.of("Administrator2")};
         final LsarLookupNamesRequest request = new LsarLookupNamesRequest(fakePolicyHandle, names, LSAPLookupLevel.LsapLookupTDL.getValue());
         assertEquals(request.toHexString(),
-            "000000008e3039708fdd9f488f9665426d0d9c5701000000010000001a001a00000002000d000000000000000d000000410064006d0069006e006900730074007200610074006f007200000000000000000000000300000000000000");
+            "000000008e3039708fdd9f488f9665426d0d9c5702000000020000001a001a00000002001c001c00040002000d000000000000000d000000410064006d0069006e006900730074007200610074006f00720000000e000000000000000e000000410064006d0069006e006900730074007200610074006f007200320000000000000000000300000000000000");
     }
 
     //This test is to verify that the Service correctly sets invalid SIDs to null from a valid response
@@ -109,6 +104,6 @@ public class Test_LookupNames {
         expectedSIDs[2] = expectedDomainSID.resolveRelativeID(501);
         expectedSIDs[3] = null;
 
-        assertArrayEquals(SIDs, expectedSIDs);
+        assertEquals(SIDs, expectedSIDs);
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/Test_LookupNames.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/Test_LookupNames.java
@@ -26,6 +26,7 @@ import com.rapid7.client.dcerpc.mslsad.messages.LsarLookupNamesResponse;
 import com.rapid7.client.dcerpc.mslsad.objects.LSAPRReferencedDomainList;
 import com.rapid7.client.dcerpc.mslsad.objects.LSAPRTranslatedSIDs;
 import com.rapid7.client.dcerpc.objects.RPCSID;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
 import com.rapid7.client.dcerpc.transport.RPCTransport;
 import java.io.IOException;
 import org.bouncycastle.util.encoders.Hex;
@@ -51,23 +52,22 @@ public class Test_LookupNames {
         final LsarLookupNamesResponse response = new LsarLookupNamesResponse();
         response.fromHexString(
             "00000200010000000400020020000000010000001a001c00080002000c0002000e000000000000000d0000005700310030002d0045004e0054002d005800360034002d005500000004000000010400000000000515000000a43cb4affe0503bd73de0f3501000000100002000100000001000000f4010000000000000100000000000000");
-        LSAPRReferencedDomainList lsaprReferencedDomainList = response.getLsaprReferencedDomainList();
-        LSAPRTranslatedSIDs lsaprTranslatedSIDs = response.getLsaprTranslatedSIDs();
+        LSAPRReferencedDomainList lsaprReferencedDomainList = response.getReferencedDomains();
+        LSAPRTranslatedSIDs lsaprTranslatedSIDs = response.getTranslatedSIDs();
 
         RPCSID expectSid = new RPCSID();
         expectSid.setRevision((char) 1);
         expectSid.setIdentifierAuthority(new byte[]{0, 0, 0, 0, 0, 5});
         expectSid.setSubAuthority(new long[]{21, 2947824804L, 3171091966L, 890232435});
-        assertEquals(lsaprReferencedDomainList.getLsaprTrustInformations()[0].getSid(), expectSid);
-        assertEquals(lsaprTranslatedSIDs.getLsaprTranslatedSIDArray()[0].getRelativeId(), 500);
+        assertEquals(lsaprReferencedDomainList.getDomains()[0].getSid(), expectSid);
+        assertEquals(lsaprTranslatedSIDs.getSIDs()[0].getRelativeId(), 500);
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void encodeLookupNamesRequest()
-        throws IOException {
+    public void encodeLookupNamesRequest() throws IOException {
         final byte[] fakePolicyHandle = Hex.decode("000000008e3039708fdd9f488f9665426d0d9c57");
-        final String[] names = {"Administrator"};
+        final RPCUnicodeString.NonNullTerminated[] names = {RPCUnicodeString.NonNullTerminated.of("Administrator")};
         final LsarLookupNamesRequest request = new LsarLookupNamesRequest(fakePolicyHandle, names);
         assertEquals(request.toHexString(), "000000008e3039708fdd9f488f9665426d0d9c5701000000010000001a001a00000002000d000000000000000d000000410064006d0069006e006900730074007200610074006f007200000000000000000000000100000000000000");
     }

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/Test_LookupNames.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/Test_LookupNames.java
@@ -63,7 +63,7 @@ public class Test_LookupNames {
     public void encodeLookupNamesRequest() throws IOException {
         final byte[] fakePolicyHandle = Hex.decode("000000008e3039708fdd9f488f9665426d0d9c57");
         final RPCUnicodeString.NonNullTerminated[] names = {RPCUnicodeString.NonNullTerminated.of("Administrator"), RPCUnicodeString.NonNullTerminated.of("Administrator2")};
-        final LsarLookupNamesRequest request = new LsarLookupNamesRequest(fakePolicyHandle, names, LSAPLookupLevel.LsapLookupWksta.getValue());
+        final LsarLookupNamesRequest request = new LsarLookupNamesRequest(fakePolicyHandle, names, LSAPLookupLevel.LSAP_LOOKUP_WKSTA.getValue());
         assertEquals(request.toHexString(), "000000008e3039708fdd9f488f9665426d0d9c5702000000020000001a001a00000002001c001c00040002000d000000000000000d000000410064006d0069006e006900730074007200610074006f00720000000e000000000000000e000000410064006d0069006e006900730074007200610074006f007200320000000000000000000100000000000000");
     }
 
@@ -72,7 +72,7 @@ public class Test_LookupNames {
     public void encodeLookupNamesRequest2() throws IOException {
         final byte[] fakePolicyHandle = Hex.decode("000000008e3039708fdd9f488f9665426d0d9c57");
         final RPCUnicodeString.NonNullTerminated[] names = {RPCUnicodeString.NonNullTerminated.of("Administrator"), RPCUnicodeString.NonNullTerminated.of("Administrator2")};
-        final LsarLookupNamesRequest request = new LsarLookupNamesRequest(fakePolicyHandle, names, LSAPLookupLevel.LsapLookupTDL.getValue());
+        final LsarLookupNamesRequest request = new LsarLookupNamesRequest(fakePolicyHandle, names, LSAPLookupLevel.LSAP_LOOKUP_TDL.getValue());
         assertEquals(request.toHexString(),
             "000000008e3039708fdd9f488f9665426d0d9c5702000000020000001a001a00000002001c001c00040002000d000000000000000d000000410064006d0069006e006900730074007200610074006f00720000000e000000000000000e000000410064006d0069006e006900730074007200610074006f007200320000000000000000000300000000000000");
     }

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/Test_LookupSIDs.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/Test_LookupSIDs.java
@@ -79,7 +79,7 @@ public class Test_LookupSIDs
         sid3.setSubAuthority(new long[]{21, 2947824804L, 3171091966L, 890232435, 500});
         final RPCSID[] rpcsids = {sid1, sid2, sid3};
         final LsarLookupSIDsRequest request = new LsarLookupSIDsRequest(fakePolicyHandle, rpcsids,
-                LSAPLookupLevel.LsapLookupWksta.getValue());
+                LSAPLookupLevel.LSAP_LOOKUP_WKSTA.getValue());
         assertEquals(request.toHexString(), "000000003a668348d29edc4db807b15d0cbf832403000000000002000300000004000200080002000c00020005000000010500000000000515000000a43cb4affe0503bd73de0f35f501000005000000010500000000000515000000a43cb4affe0503bd73de0f35e903000005000000010500000000000515000000a43cb4affe0503bd73de0f35f401000000000000000000000100000000000000");
     }
 
@@ -105,7 +105,7 @@ public class Test_LookupSIDs
         sid3.setSubAuthority(new long[] { 21, 2947824804L, 3171091966L, 890232435, 500 });
         final RPCSID[] rpcsids = { sid1, sid2, sid3 };
         final LsarLookupSIDsRequest request = new LsarLookupSIDsRequest(fakePolicyHandle, rpcsids,
-                LSAPLookupLevel.LsapLookupTDL.getValue());
+                LSAPLookupLevel.LSAP_LOOKUP_TDL.getValue());
         assertEquals(request.toHexString(),
             "000000003a668348d29edc4db807b15d0cbf832403000000000002000300000004000200080002000c00020005000000010500000000000515000000a43cb4affe0503bd73de0f35f501000005000000010500000000000515000000a43cb4affe0503bd73de0f35e903000005000000010500000000000515000000a43cb4affe0503bd73de0f35f401000000000000000000000300000000000000");
     }

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/Test_LookupSIDs.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/Test_LookupSIDs.java
@@ -41,14 +41,14 @@ public class Test_LookupSIDs
         final LsarLookupSIDsResponse response = new LsarLookupSIDsResponse();
         response.fromHexString(
             "00000200010000000400020020000000010000001a001c00080002000c0002000e000000000000000d0000005700310030002d0045004e0054002d005800360034002d005500000004000000010400000000000515000000a43cb4affe0503bd73de0f3504000000100002000400000001000000080008001400020000000000010000001a001a001800020000000000010000000a000a001c000200000000000300000000000000000000000000000004000000000000000400000075007300650072000d000000000000000d000000410064006d0069006e006900730074007200610074006f00720000000500000000000000050000004700750065007300740000000400000000000000");
-        LSAPRReferencedDomainList lsaprReferencedDomainList = response.getLsaprReferencedDomainList();
-        LSAPRTranslatedName[] lsaprTranslatedNames = response.getLsaprTranslatedNames().getlsaprTranslatedNameArray();
+        LSAPRReferencedDomainList lsaprReferencedDomainList = response.getReferencedDomains();
+        LSAPRTranslatedName[] lsaprTranslatedNames = response.getTranslatedNames().getNames();
 
         RPCSID expectSid = new RPCSID();
         expectSid.setRevision((char) 1);
         expectSid.setIdentifierAuthority(new byte[]{0, 0, 0, 0, 0, 5});
         expectSid.setSubAuthority(new long[]{21, 2947824804L, 3171091966L, 890232435});
-        assertEquals(lsaprReferencedDomainList.getLsaprTrustInformations()[0].getSid(), expectSid);
+        assertEquals(lsaprReferencedDomainList.getDomains()[0].getSid(), expectSid);
 
         String [] expectedMappings = new String[]{"user", "Administrator", "Guest", null};
         for (int i = 0; i < lsaprTranslatedNames.length; i++){


### PR DESCRIPTION
- Conformant arrays were being marshalled/unmarshalled incorrectly. Using proper preamble-entity-deferral strategy now
- Some alignments were missing, which cause issues for multiple entries
- Methods have been renamed to reflect the RPC layer documentation
- Documentation has been added where it was missing