### PR TITLE
Added getKeySecurity method to RegistryService

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/RegistryService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/RegistryService.java
@@ -18,19 +18,35 @@
  */
 package com.rapid7.client.dcerpc.msrrp;
 
+import static com.rapid7.client.dcerpc.mserref.SystemErrorCode.ERROR_NO_MORE_ITEMS;
+import static com.rapid7.client.dcerpc.mserref.SystemErrorCode.ERROR_SUCCESS;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import com.google.common.base.Strings;
 import com.hierynomus.msdtyp.AccessMask;
 import com.rapid7.client.dcerpc.RPCException;
 import com.rapid7.client.dcerpc.messages.HandleResponse;
-import com.rapid7.client.dcerpc.msrrp.messages.*;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegEnumKeyRequest;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegEnumKeyResponse;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegEnumValueRequest;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegEnumValueResponse;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegGetKeySecurityRequest;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegGetKeySecurityResponse;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegOpenKey;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegQueryInfoKeyRequest;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegQueryInfoKeyResponse;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegQueryValueRequest;
+import com.rapid7.client.dcerpc.msrrp.messages.BaseRegQueryValueResponse;
+import com.rapid7.client.dcerpc.msrrp.messages.HandleRequest;
 import com.rapid7.client.dcerpc.objects.FileTime;
 import com.rapid7.client.dcerpc.service.Service;
 import com.rapid7.client.dcerpc.transport.RPCTransport;
-
-import static com.rapid7.client.dcerpc.mserref.SystemErrorCode.ERROR_NO_MORE_ITEMS;
-import static com.rapid7.client.dcerpc.mserref.SystemErrorCode.ERROR_SUCCESS;
 
 /**
  * This class implements a partial registry service in accordance with [MS-RRP]: Windows Remote Registry Protocol which
@@ -45,6 +61,8 @@ public class RegistryService extends Service {
     private final static int MAX_REGISTRY_VALUE_NAME_SIZE = 32767;
     private final static int MAX_REGISTRY_VALUE_DATA_SIZE = 1048576;
     private final static EnumSet<AccessMask> ACCESS_MASK = EnumSet.of(AccessMask.MAXIMUM_ALLOWED);
+    private final static EnumSet<AccessMask> SYSTEM_ACCESS = EnumSet.of(AccessMask.MAXIMUM_ALLOWED,
+        AccessMask.ACCESS_SYSTEM_SECURITY);
     private final Map<RegistryHive, byte[]> hiveCache = new HashMap<>();
     private final Map<String, byte[]> keyPathCache = new HashMap<>();
 
@@ -103,7 +121,7 @@ public class RegistryService extends Service {
             if (ERROR_SUCCESS.is(returnCode)) {
                 keyNames.add(new RegistryKey(response.getName(), new FileTime(response.getLastWriteTime())));
             } else if (ERROR_NO_MORE_ITEMS.is(returnCode)) {
-                return Collections.unmodifiableList(new ArrayList<RegistryKey>(keyNames));
+                return Collections.unmodifiableList(new ArrayList<>(keyNames));
             } else {
                 throw new RPCException("BaseRegEnumKey", returnCode);
             }
@@ -121,7 +139,7 @@ public class RegistryService extends Service {
             if (ERROR_SUCCESS.is(returnCode)) {
                 values.add(new RegistryValue(response.getName(), response.getType(), response.getData()));
             } else if (ERROR_NO_MORE_ITEMS.is(returnCode)) {
-                return Collections.unmodifiableList(new ArrayList<RegistryValue>(values));
+                return Collections.unmodifiableList(new ArrayList<>(values));
             } else {
                 throw new RPCException("BaseRegEnumValue", returnCode);
             }
@@ -135,6 +153,16 @@ public class RegistryService extends Service {
         final BaseRegQueryValueRequest request = new BaseRegQueryValueRequest(handle, canonicalizedValueName, MAX_REGISTRY_VALUE_DATA_SIZE);
         final BaseRegQueryValueResponse response = callExpectSuccess(request, "BaseRegQueryValue");
         return new RegistryValue(canonicalizedValueName, response.getType(), response.getData());
+    }
+
+    public byte[] getKeySecurity(final String hiveName, final String keyPath, final int securityDescriptorType)
+            throws IOException {
+        final byte[] handle = openKey(hiveName, keyPath, SYSTEM_ACCESS);
+        final int size = getKeyInfo(hiveName, keyPath).getSecurityDescriptor();
+        final BaseRegGetKeySecurityRequest request = new BaseRegGetKeySecurityRequest(handle, securityDescriptorType,
+                size);
+        final BaseRegGetKeySecurityResponse response = callExpectSuccess(request, "BaseRegGetKeySecurity");
+        return response.getRawSecurityDescriptor();
     }
 
     protected String canonicalize(String keyPath) {
@@ -171,7 +199,11 @@ public class RegistryService extends Service {
         }
     }
 
-    protected byte[] openKey(final String hiveName, final String keyPath) throws IOException {
+    public byte[] openKey(final String hiveName, final String keyPath) throws IOException {
+        return openKey(hiveName, keyPath, ACCESS_MASK);
+    }
+
+    public byte[] openKey(final String hiveName, final String keyPath, EnumSet<AccessMask> access) throws IOException {
         final String canonicalizedKeyPath = canonicalize(keyPath);
         if (canonicalizedKeyPath.isEmpty()) {
             return openHive(hiveName);
@@ -181,11 +213,12 @@ public class RegistryService extends Service {
                 return keyPathCache.get(canonicalizedKeyPath);
             }
             final byte[] hiveHandle = openHive(hiveName);
-            final BaseRegOpenKey request = new BaseRegOpenKey(hiveHandle, canonicalizedKeyPath, 0, ACCESS_MASK);
+            final BaseRegOpenKey request = new BaseRegOpenKey(hiveHandle, canonicalizedKeyPath, 0, access);
             final HandleResponse response = callExpectSuccess(request, "BaseRegOpenKey");
             final byte[] keyHandle = response.getHandle();
             keyPathCache.put(canonicalizedKeyPath, keyHandle);
             return keyHandle;
         }
     }
+
 }

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegGetKeySecurityRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegGetKeySecurityRequest.java
@@ -83,7 +83,6 @@ public class BaseRegGetKeySecurityRequest extends RequestCall<BaseRegGetKeySecur
         out.writeInt(securityDescriptorInfo);
         final RPCSecurityDescriptor sd = new RPCSecurityDescriptor();
         sd.setCbInSecurityDescriptor(securityDescriptorSize);
-        sd.setSecurityDescriptor(new byte[securityDescriptorSize]);
         out.writeMarshallable(sd);
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegGetKeySecurityRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegGetKeySecurityRequest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ */
+package com.rapid7.client.dcerpc.msrrp.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.messages.RequestCall;
+import com.rapid7.client.dcerpc.msrrp.objects.RPCSecurityDescriptor;
+
+public class BaseRegGetKeySecurityRequest extends RequestCall<BaseRegGetKeySecurityResponse> {
+    public static short OP_NUM = 12;
+    private final byte[] hKey;
+    private final int securityDescriptorInfo;
+    private final int securityDescriptorSize;
+
+    public BaseRegGetKeySecurityRequest(byte[] hKey, int securityDescriptorInfo, int securityDescriptorSize) {
+        super(OP_NUM);
+        this.hKey = hKey;
+        this.securityDescriptorInfo = securityDescriptorInfo;
+        this.securityDescriptorSize = securityDescriptorSize;
+    }
+
+    @Override
+    public void marshal(PacketOutput out) throws IOException {
+        out.write(hKey);
+        out.writeInt(securityDescriptorInfo);
+        RPCSecurityDescriptor sd = new RPCSecurityDescriptor();
+        sd.setMaxSize(securityDescriptorSize);
+        out.writeMarshallable(sd);
+    }
+
+    @Override
+    public BaseRegGetKeySecurityResponse getResponseObject() {
+        return new BaseRegGetKeySecurityResponse();
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegGetKeySecurityRequest.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegGetKeySecurityRequest.java
@@ -23,13 +23,54 @@ import com.rapid7.client.dcerpc.io.PacketOutput;
 import com.rapid7.client.dcerpc.messages.RequestCall;
 import com.rapid7.client.dcerpc.msrrp.objects.RPCSecurityDescriptor;
 
+/**
+<p>The BaseRegGetKeySecurity method is called by the client. In
+response, the server returns a copy of the security descriptor that protects
+the specified open registry key.</p>
+
+<pre> error_status_t BaseRegGetKeySecurity(
+   [in] RPC_HKEY hKey,
+   [in] SECURITY_INFORMATION SecurityInformation,
+   [in] PRPC_SECURITY_DESCRIPTOR pRpcSecurityDescriptorIn,
+   [out] PRPC_SECURITY_DESCRIPTOR pRpcSecurityDescriptorOut
+ );
+</pre>
+
+<p><strong>hKey: </strong>A handle to a key that MUST have been
+opened previously by using one of the open methods that are specified in
+section <a href="https://msdn.microsoft.com/en-us/library/cc244912.aspx">3.1.5</a>: <a href="https://msdn.microsoft.com/en-us/library/cc244950.aspx">OpenClassesRoot</a>, <a href="https://msdn.microsoft.com/en-us/library/cc244952.aspx">OpenCurrentUser</a>, <a href="https://msdn.microsoft.com/en-us/library/cc244953.aspx">OpenLocalMachine</a>, <a href="https://msdn.microsoft.com/en-us/library/cc244954.aspx">OpenPerformanceData</a>, <a href="https://msdn.microsoft.com/en-us/library/cc244957.aspx">OpenUsers</a>, <a href="https://msdn.microsoft.com/en-us/library/cc244929.aspx">BaseRegCreateKey</a>, <a href="https://msdn.microsoft.com/en-us/library/cc244939.aspx">BaseRegOpenKey</a>, <a href="https://msdn.microsoft.com/en-us/library/cc244951.aspx">OpenCurrentConfig</a>, <a href="https://msdn.microsoft.com/en-us/library/cc244956.aspx">OpenPerformanceText</a>, <a href="https://msdn.microsoft.com/en-us/library/cc244955.aspx">OpenPerformanceNlsText</a>.</p>
+
+<p><strong>SecurityInformation:</strong> The information that is
+needed to determine the type of security that is returned in <em>pRpcSecurityDescriptorOut</em>.
+See <a href="https://msdn.microsoft.com/en-us/library/cc244926.aspx">SECURITY_INFORMATION</a>
+(includes a list of possible <a href="https://msdn.microsoft.com/en-us/library/cc244893.aspx#gt_7bc13a0c-ca1a-4c78-b1bf-67e243f778bb">values</a>).</p>
+
+<p><strong>pRpcSecurityDescriptorIn: </strong>A pointer to a
+buffer containing a security descriptor. The client MUST provide a pointer to a
+<a href="https://msdn.microsoft.com/en-us/library/cc244924.aspx">RPC_SECURITY_DESCRIPTOR</a>
+with arbitrary contents. The server uses the size of this security descriptor
+to validate the client has the correct amount of memory allocated for the
+RPC_SECURITY_DESCRIPTOR pointed to by the <em>pRpcSecurityDescriptorOut</em>
+parameter</p>
+
+<p><strong>pRpcSecurityDescriptorOut:</strong> A pointer to a
+buffer to which the requested security descriptor MUST be written.</p>
+
+<p><strong>Return Values: </strong>The method returns 0
+(ERROR_SUCCESS) to indicate success; otherwise, it returns a nonzero error
+code, as specified in <a href="https://msdn.microsoft.com/en-us/library/cc231196.aspx">[MS-ERREF]</a>
+section <a href="https://msdn.microsoft.com/en-us/library/cc231199.aspx">2.2</a>.
+The most common error codes are listed in the following table.</p>
+@see <a href="https://msdn.microsoft.com/en-us/library/cc244936.aspx">https://msdn.microsoft.com/en-us/library/cc244936.aspx</a>
+ */
 public class BaseRegGetKeySecurityRequest extends RequestCall<BaseRegGetKeySecurityResponse> {
     public static short OP_NUM = 12;
     private final byte[] hKey;
     private final int securityDescriptorInfo;
     private final int securityDescriptorSize;
 
-    public BaseRegGetKeySecurityRequest(byte[] hKey, int securityDescriptorInfo, int securityDescriptorSize) {
+    public BaseRegGetKeySecurityRequest(final byte[] hKey, final int securityDescriptorInfo,
+            final int securityDescriptorSize) {
         super(OP_NUM);
         this.hKey = hKey;
         this.securityDescriptorInfo = securityDescriptorInfo;
@@ -37,11 +78,12 @@ public class BaseRegGetKeySecurityRequest extends RequestCall<BaseRegGetKeySecur
     }
 
     @Override
-    public void marshal(PacketOutput out) throws IOException {
+    public void marshal(final PacketOutput out) throws IOException {
         out.write(hKey);
         out.writeInt(securityDescriptorInfo);
-        RPCSecurityDescriptor sd = new RPCSecurityDescriptor();
-        sd.setMaxSize(securityDescriptorSize);
+        final RPCSecurityDescriptor sd = new RPCSecurityDescriptor();
+        sd.setCbInSecurityDescriptor(securityDescriptorSize);
+        sd.setSecurityDescriptor(new byte[securityDescriptorSize]);
         out.writeMarshallable(sd);
     }
 

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegGetKeySecurityResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegGetKeySecurityResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ */
+package com.rapid7.client.dcerpc.msrrp.messages;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.messages.RequestResponse;
+import com.rapid7.client.dcerpc.msrrp.objects.RPCSecurityDescriptor;
+
+public class BaseRegGetKeySecurityResponse extends RequestResponse {
+    private RPCSecurityDescriptor securityDescriptorOut;
+
+    public byte[] getRawSecurityDescriptor() {
+        return securityDescriptorOut.getRawSecurityDescriptor();
+    }
+
+    @Override
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
+        securityDescriptorOut = new RPCSecurityDescriptor();
+        packetIn.readUnmarshallable(securityDescriptorOut);
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegOpenKey.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/messages/BaseRegOpenKey.java
@@ -19,9 +19,6 @@
 package com.rapid7.client.dcerpc.msrrp.messages;
 
 import java.io.IOException;
-import java.util.EnumSet;
-import com.hierynomus.msdtyp.AccessMask;
-import com.hierynomus.protocol.commons.EnumWithValue.EnumUtils;
 import com.rapid7.client.dcerpc.io.PacketOutput;
 import com.rapid7.client.dcerpc.messages.HandleResponse;
 import com.rapid7.client.dcerpc.messages.RequestCall;
@@ -248,7 +245,7 @@ public class BaseRegOpenKey extends RequestCall<HandleResponse> {
      * </tr>
      * </table>
      */
-    private final EnumSet<AccessMask> accessMask;
+    private final int accessMask;
 
     /**
      * The BaseRegOpenKey method is called by the client. In response, the server opens a specified key for access and
@@ -327,7 +324,7 @@ public class BaseRegOpenKey extends RequestCall<HandleResponse> {
      * @see <a href="https://msdn.microsoft.com/en-us/cc230294">2.4.3 ACCESS_MASK</a>
      * @see <a href="https://msdn.microsoft.com/en-us/cc244886">3.1.1.2 Key Types</a>
      */
-    public BaseRegOpenKey(final byte[] hKey, final String subKey, final int options, final EnumSet<AccessMask> accessMask) {
+    public BaseRegOpenKey(final byte[] hKey, final String subKey, final int options, final int accessMask) {
         super((short) 15);
         this.hKey = hKey;
         this.subKey = subKey;
@@ -369,6 +366,6 @@ public class BaseRegOpenKey extends RequestCall<HandleResponse> {
         packetOut.write(hKey);
         packetOut.writeStringBuffer(subKey, true);
         packetOut.writeInt(options);
-        packetOut.writeInt((int) EnumUtils.toLong(accessMask));
+        packetOut.writeInt(accessMask);
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/msrrp/objects/RPCSecurityDescriptor.java
+++ b/src/main/java/com/rapid7/client/dcerpc/msrrp/objects/RPCSecurityDescriptor.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ */
+package com.rapid7.client.dcerpc.msrrp.objects;
+
+import java.io.IOException;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.io.ndr.Marshallable;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+
+public class RPCSecurityDescriptor implements Unmarshallable, Marshallable {
+    private int size;
+    private int maxSize;
+    private int offset;
+    private byte[] rawSecurityDescriptor;
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    public void setMaxSize(int size) {
+        this.maxSize = size;
+    }
+
+    public RPCSecurityDescriptor() {
+
+    }
+
+    @Override
+    public void unmarshalPreamble(PacketInput in) throws IOException {
+    }
+
+    @Override
+    public void unmarshalEntity(PacketInput in) throws IOException {
+        in.align(Alignment.FOUR);
+        in.readReferentID();
+        in.readInt();
+        in.readInt();
+    }
+
+    @Override
+    public void unmarshalDeferrals(PacketInput in) throws IOException {
+        in.align(Alignment.FOUR);
+        maxSize = in.readInt();
+        offset = in.readInt();
+        size = in.readInt();
+        // TODO: Return parsed object.
+        rawSecurityDescriptor = in.readRawBytes(size);
+    }
+
+    @Override
+    public void marshalPreamble(PacketOutput out) throws IOException {
+    }
+
+    @Override
+    public void marshalEntity(PacketOutput out) throws IOException {
+        out.writeReferentID();
+        out.writeInt(maxSize);
+        out.writeInt(size);
+    }
+
+    @Override
+    public void marshalDeferrals(PacketOutput out) throws IOException {
+        out.writeInt(maxSize);
+        out.writeInt(offset);
+        out.writeInt(size);
+    }
+
+    public byte[] getRawSecurityDescriptor() {
+        return rawSecurityDescriptor;
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/msrrp/messages/Test_BaseRegOpenKey.java
+++ b/src/test/java/com/rapid7/client/dcerpc/msrrp/messages/Test_BaseRegOpenKey.java
@@ -18,21 +18,23 @@
  */
 package com.rapid7.client.dcerpc.msrrp.messages;
 
+import static org.bouncycastle.util.encoders.Hex.toHexString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.util.EnumSet;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 import com.hierynomus.msdtyp.AccessMask;
+import com.hierynomus.protocol.commons.EnumWithValue.EnumUtils;
 import com.rapid7.client.dcerpc.messages.HandleResponse;
-
-import static org.bouncycastle.util.encoders.Hex.toHexString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class Test_BaseRegOpenKey {
     private final byte[] contextHandle = Hex.decode("0000000032daf234b77c86409d29efe60d326683");
-    private final BaseRegOpenKey request = new BaseRegOpenKey(contextHandle, "Software\\Microsoft\\Windows NT\\CurrentVersion", 0, EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
+    private final BaseRegOpenKey request = new BaseRegOpenKey(contextHandle,
+            "Software\\Microsoft\\Windows NT\\CurrentVersion", 0,
+            (int) EnumUtils.toLong(EnumSet.of(AccessMask.MAXIMUM_ALLOWED)));
 
     @Test
     public void getOpNum() {


### PR DESCRIPTION
Added an argument to openKey to allow setting desired access. For some reason maximum allowed does not provide system security access.

Added a method in RegistryService to getKeySecurity.

Tested by getting SACL and DACL for HKLM/System/CurrentControlSet on a windows target.