### PR TITLE
Adds WChar struct

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
@@ -650,6 +650,15 @@ public class SecurityAccountManagerService extends Service {
         return callExpectSuccess(request, "SamrQuerySecurityObject").getSecurityDescriptor().getSecurityDescriptor();
     }
 
+    /**
+     * Gets the SID of a given domain. An exception is thrown if it is not found.
+     *
+     * @param serverHandle A valid server handle obtained from {@link #openServer()}
+     * @param domainName The name of the domain to get the {@link SID} for.
+     * @return The SID for the given domain.
+     * @throws IOException Thrown if either a communication failure is encountered, or the call
+     * returns an unsuccessful response.
+     */
     public SID getSIDForDomain(final ServerHandle serverHandle, final String domainName) throws IOException {
         final SamrLookupDomainInSamServerRequest request =
                 new SamrLookupDomainInSamServerRequest(
@@ -658,6 +667,17 @@ public class SecurityAccountManagerService extends Service {
         return parseRPCSID(rpcsid);
     }
 
+    /**
+     * Gets an array of {@link MembershipWithUse} information for users/groups matching the given names in the provided
+     * domain.
+     *
+     * @param domainHandle A valid domain handle obtained from {@link #openDomain(ServerHandle, SID)}
+     * @param names A list of user/group names.
+     * @return An array of user/group relativeIDs and their use; each entry corresponds 1-1 with the given name list.
+     * If an entry is null, no result was found for that name.
+     * @throws IOException Thrown if either a communication failure is encountered, or the call
+     * returns an unsuccessful response.
+     */
     public MembershipWithUse[] getNamesInDomain(final DomainHandle domainHandle, String ... names) throws IOException {
         final SamrLookupNamesInDomainRequest request =
                 new SamrLookupNamesInDomainRequest(parseHandle(domainHandle), parseNonNullTerminatedStrings(names));
@@ -686,7 +706,10 @@ public class SecurityAccountManagerService extends Service {
     /**
      * Gets a list of {@link MembershipWithAttributes} information for groups containing the provided user handle.
      *
-     * @param userHandle User handle. Must not be {@code null}.
+     * @param userHandle A valid user handle obtained from {@link #openUser(DomainHandle, long)}
+     * @return An array of groups with their relativeIDs and attributes that the user belongs to.
+     * @throws IOException Thrown if either a communication failure is encountered, or the call
+     * returns an unsuccessful response.
      */
     public MembershipWithAttributes[] getGroupsForUser(final UserHandle userHandle) throws IOException {
         final SamrGetGroupsForUserRequest request = new SamrGetGroupsForUserRequest(parseHandle(userHandle));
@@ -697,7 +720,10 @@ public class SecurityAccountManagerService extends Service {
     /**
      * Gets a list of {@link MembershipWithAttributes} information for the members of the provided group handle.
      *
-     * @param groupHandle Group handle. Must not be {@code null}.
+     * @param groupHandle A valid group handle obtained from {@link #openGroup(DomainHandle, long)}
+     * @return An array of user/group relativeIDs and their attributes that belong to the given group.
+     * @throws IOException Thrown if either a communication failure is encountered, or the call
+     * returns an unsuccessful response.
      */
     public MembershipWithAttributes[] getMembersForGroup(GroupHandle groupHandle) throws IOException {
         final SamrGetMembersInGroupRequest request = new SamrGetMembersInGroupRequest(parseHandle(groupHandle));
@@ -711,7 +737,8 @@ public class SecurityAccountManagerService extends Service {
      * @param domainHandle The domain handle.
      * @param sids A list of SIDs.
      * @return An array of alias relativeIDs to the provided SID.
-     * @throws IOException
+     * @throws IOException Thrown if either a communication failure is encountered, or the call
+     * returns an unsuccessful response.
      */
     public Integer[] getAliasMembership(final DomainHandle domainHandle, SID... sids) throws IOException {
         final SamrGetAliasMembershipRequest request =

--- a/src/main/java/com/rapid7/client/dcerpc/objects/RPCUnicodeString.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/RPCUnicodeString.java
@@ -83,7 +83,7 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
         }
 
         @Override
-        WChar newWChar() {
+        WChar createWChar() {
             return new WChar.NullTerminated();
         }
     }
@@ -103,13 +103,13 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
         }
 
         @Override
-        WChar newWChar() {
+        WChar createWChar() {
             return new WChar.NonNullTerminated();
         }
     }
 
     private WChar wChar;
-    abstract WChar newWChar();
+    abstract WChar createWChar();
 
     /**
      * @return The {@link String} representation of this {@link RPCUnicodeString}.
@@ -129,7 +129,7 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
         if (value == null) {
             this.wChar = null;
         } else {
-            this.wChar = newWChar();
+            this.wChar = createWChar();
             this.wChar.setValue(value);
         }
     }
@@ -194,8 +194,7 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
         // <NDR: pointer> [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer;
         // Alignment: 4 - Already aligned
         if (in.readReferentID() != 0)
-            // This is 0 cost - Compile time constants are internal objects
-            this.wChar = newWChar();
+            this.wChar = createWChar();
         else
             this.wChar = null;
     }

--- a/src/main/java/com/rapid7/client/dcerpc/objects/RPCUnicodeString.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/RPCUnicodeString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017, Rapid7, Inc.
  *
  * License: BSD-3-clause
@@ -19,7 +19,6 @@
 package com.rapid7.client.dcerpc.objects;
 
 import java.io.IOException;
-import java.rmi.UnmarshalException;
 import java.util.Objects;
 import com.rapid7.client.dcerpc.io.PacketInput;
 import com.rapid7.client.dcerpc.io.PacketOutput;
@@ -60,10 +59,10 @@ import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
  * <br>
  * <b>Marshalling Usage:</b><pre>
  *      String myValue = "some string";
- *      RPC_UNICODE_STRING rpcUnicodeString = RPC_UNICODE_STRING.of(true, myValue);
+ *      RPCUnicodeString rpcUnicodeString = RPCUnicodeString.NonNullTerminated.of(myValue);
  *      packetOut.writeMarshallable(rpcUnicodeString);</pre>
  * <b>Unmarshalling Usage:</b><pre>
- *      RPC_UNICODE_STRING rpcUnicodeString = RPC_UNICODE_STRING.of(true);
+ *      RPCUnicodeString rpcUnicodeString = new RPCUnicodeString.NonNullTerminated();
  *      packetIn.readUnmarshallable(rpcUnicodeString);
  *      String myValue = rpcUnicodeString.getValue();</pre>
  */
@@ -73,15 +72,19 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
      * An RPC_UNICODE_STRING which is expected to be null terminated during marshalling/unmarshalling.
      */
     public static class NullTerminated extends RPCUnicodeString {
+        /**
+         * @param value The value; may be null.
+         * @return A new {@link NullTerminated} {@link RPCUnicodeString} with the provided value.
+         */
         public static NullTerminated of(String value) {
-            NullTerminated str = new NullTerminated();
+            final NullTerminated str = new NullTerminated();
             str.setValue(value);
             return str;
         }
 
         @Override
-        boolean isNullTerminated() {
-            return true;
+        WChar newWChar() {
+            return new WChar.NullTerminated();
         }
     }
 
@@ -89,28 +92,46 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
      * An RPC_UNICODE_STRING which is not expected to be null terminated during marshalling/unmarshalling.
      */
     public static class NonNullTerminated extends RPCUnicodeString {
+        /**
+         * @param value The value; may be null.
+         * @return A new {@link NonNullTerminated} {@link RPCUnicodeString} with the provided value.
+         */
         public static NonNullTerminated of(String value) {
-            NonNullTerminated str = new NonNullTerminated();
+            final NonNullTerminated str = new NonNullTerminated();
             str.setValue(value);
             return str;
         }
 
         @Override
-        boolean isNullTerminated() {
-            return false;
+        WChar newWChar() {
+            return new WChar.NonNullTerminated();
         }
     }
 
-    private String value;
+    private WChar wChar;
+    abstract WChar newWChar();
 
-    abstract boolean isNullTerminated();
-
+    /**
+     * @return The {@link String} representation of this {@link RPCUnicodeString}.
+     * May be null. Will never include a null terminator.
+     */
     public String getValue() {
-        return value;
+        if (this.wChar == null)
+            return null;
+        return this.wChar.getValue();
     }
 
+    /**
+     * @param value The {@link String} representation for this {@link RPCUnicodeString}.
+     * May be null. Must not include a null terminator.
+     */
     public void setValue(String value) {
-        this.value = value;
+        if (value == null) {
+            this.wChar = null;
+        } else {
+            this.wChar = newWChar();
+            this.wChar.setValue(value);
+        }
     }
 
     @Override
@@ -122,7 +143,7 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
     public void marshalEntity(PacketOutput out) throws IOException {
         // Structure Alignment
         out.align(Alignment.FOUR);
-        if (value == null) {
+        if (this.wChar == null) {
             // <NDR: unsigned short> unsigned short Length;
             // Alignment 2 - Already aligned
             out.writeShort(0);
@@ -135,7 +156,7 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
         } else {
             // UTF-16 encoded string is 2 bytes per count point
             // Null terminator must also be considered
-            final int byteLength = 2 * value.length() + (isNullTerminated() ? 2 : 0);
+            final int byteLength = 2 * this.wChar.getValue().length() + (this.wChar.isNullTerminated() ? 2 : 0);
             // <NDR: unsigned short> unsigned short Length;
             // Alignment 2 - Already aligned
             out.writeShort(byteLength);
@@ -150,22 +171,8 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
 
     @Override
     public void marshalDeferrals(PacketOutput out) throws IOException {
-        if (value != null) {
-            final int codepoints = value.length() + (isNullTerminated() ? 1 : 0);
-            // MaximumCount for conformant array
-            out.align(Alignment.FOUR);
-            out.writeInt(codepoints);
-            // Offset for varying array
-            // Alignment 4 - Already aligned
-            out.writeInt(0);
-            // ActualCount for varying array
-            // Alignment 4 - Already aligned
-            out.writeInt(codepoints);
-            // Entities for conformant+varying array
-            // Alignment 1 - Already aligned
-            out.writeChars(value);
-            if (isNullTerminated())
-                out.writeShort(0);
+        if (this.wChar != null) {
+            out.writeMarshallable(this.wChar);
         }
     }
 
@@ -188,49 +195,21 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
         // Alignment: 4 - Already aligned
         if (in.readReferentID() != 0)
             // This is 0 cost - Compile time constants are internal objects
-            value = "";
+            this.wChar = newWChar();
+        else
+            this.wChar = null;
     }
 
     @Override
     public void unmarshalDeferrals(PacketInput in) throws IOException {
-        if (value != null) {
-            //Preamble
-            // <NDR: unsigned long> MaximumCount for conformant array - This is *not* the size of the array, so is not useful to us
-            in.align(Alignment.FOUR);
-            in.fullySkipBytes(4);
-
-            //Entity
-            // <NDR: unsigned long> Offset for varying array
-            // Alignment: 4 - Already aligned
-            final int offset = readIndex("Offset", in);
-            // <NDR: unsigned long> ActualCount for varying array
-            // Alignment: 4 - Already aligned
-            final int actualCount = readIndex("ActualCount", in);
-            // If we expect a null terminator, then skip it when reading the string
-            final int stringCount = (isNullTerminated() ? (actualCount - 1) : actualCount);
-
-            //Deferrals
-            // Entities for conformant array
-            final StringBuilder result = new StringBuilder(stringCount);
-            // Read prefix (if any)
-            // Alignment: 2 - Already aligned
-            in.fullySkipBytes(2 * offset);
-            // Read subset
-            for (int i = 0; i < stringCount; i++) {
-                // <NDR: unsigned short>
-                // Alignment: 2 - Already aligned
-                result.append((char) in.readShort());
-            }
-            // Read suffix (if any)
-            // Alignment: 2 - Already aligned
-            in.fullySkipBytes(2 * (actualCount-stringCount));
-            this.value = result.toString();
+        if (this.wChar != null) {
+            in.readUnmarshallable(this.wChar);
         }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isNullTerminated(), getValue());
+        return Objects.hash(wChar);
     }
 
     @Override
@@ -240,24 +219,11 @@ public abstract class RPCUnicodeString implements Unmarshallable, Marshallable {
         } else if (! (obj instanceof RPCUnicodeString)) {
             return false;
         }
-        RPCUnicodeString other = (RPCUnicodeString) obj;
-        return Objects.equals(isNullTerminated(), other.isNullTerminated())
-                && Objects.equals(getValue(), other.getValue());
+        return Objects.equals(wChar, ((RPCUnicodeString) obj).wChar);
     }
 
     @Override
     public String toString() {
-        return String.format("RPC_UNICODE_STRING{value:%s, nullTerminated:%b}",
-                getValue() == null ? "null" : String.format("\"%s\"", getValue()),
-                isNullTerminated());
-    }
-
-    private int readIndex(String name, PacketInput in) throws IOException {
-        final long ret = in.readUnsignedInt();
-        // Don't allow array length or index values bigger than signed int
-        if (ret > Integer.MAX_VALUE) {
-            throw new UnmarshalException(String.format("%s %d > %d", name, ret, Integer.MAX_VALUE));
-        }
-        return (int) ret;
+        return getValue() == null ? "null" : String.format("\"%s\"", getValue());
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/objects/WChar.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/WChar.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ */
+package com.rapid7.client.dcerpc.objects;
+
+import java.io.IOException;
+import java.rmi.UnmarshalException;
+import java.util.Objects;
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
+import com.rapid7.client.dcerpc.io.ndr.Marshallable;
+import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
+
+/**
+ * Represents a UTF-16 encoded unicode string as a character array.
+ * <b>Alignment: 4</b>
+ *
+ * <b>Marshalling Usage:</b><pre>
+ *      String myValue = "some string";
+ *      WChar wChar = WChar.NonNullTerminated.of(myValue);
+ *      packetOut.writeMarshallable(wChar);</pre>
+ * <b>Unmarshalling Usage:</b><pre>
+ *      WChar wChar = new WChar.NonNullTerminated();
+ *      packetIn.readUnmarshallable(wChar);
+ *      String myValue = wChar.getValue();</pre>
+ */
+public abstract class WChar implements Unmarshallable, Marshallable {
+
+    /**
+     * An WCHAR which is expected to be null terminated during marshalling/unmarshalling.
+     */
+    public static class NullTerminated extends WChar {
+        /**
+         * @param value The value, must not be null.
+         * @return A new {@link NullTerminated} {@link WChar} with the provided value.
+         */
+        public static NullTerminated of(String value) {
+            final NullTerminated ret = new NullTerminated();
+            ret.setValue(value);
+            return ret;
+        }
+
+        @Override
+        public boolean isNullTerminated() {
+            return true;
+        }
+    }
+
+    /**
+     * An WCHAR which is not expected to be null terminated during marshalling/unmarshalling.
+     */
+    public static class NonNullTerminated extends WChar {
+        /**
+         * @param value The value, must not be null.
+         * @return A new {@link NonNullTerminated} {@link WChar} with the provided value.
+         */
+        public static NonNullTerminated of(String value) {
+            final NonNullTerminated ret = new NonNullTerminated();
+            ret.setValue(value);
+            return ret;
+        }
+
+        @Override
+        public boolean isNullTerminated() {
+            return false;
+        }
+    }
+
+    private String value = "";
+    // Stored for unmarshalling purposes only
+    private int offset;
+    private int length;
+
+    public abstract boolean isNullTerminated();
+
+    /**
+     * @return The non-null String representation of this {@link WChar}.
+     */
+    public String getValue() {
+        return this.value;
+    }
+
+    /**
+     * @param value The non-null String representation for this {@link WChar}.
+     */
+    public void setValue(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Expected non-null value");
+        }
+        this.value = value;
+    }
+
+    @Override
+    public void marshalPreamble(PacketOutput out) throws IOException {
+        // MaximumCount for conformant array
+        out.align(Alignment.FOUR);
+        out.writeInt(getCodePoints());
+    }
+
+    @Override
+    public void marshalEntity(PacketOutput out) throws IOException {
+        // Structure Alignment: 4
+        out.align(Alignment.FOUR);
+        // Offset for varying array
+        // Alignment 4 - Already aligned
+        out.writeInt(0);
+        // ActualCount for varying array
+        // Alignment 4 - Already aligned
+        out.writeInt(getCodePoints());
+    }
+
+    @Override
+    public void marshalDeferrals(PacketOutput out) throws IOException {
+        // Entities for conformant+varying array
+        // Alignment 1 - Already aligned
+        out.writeChars(value);
+        if (isNullTerminated())
+            out.writeShort(0);
+    }
+
+    @Override
+    public void unmarshalPreamble(PacketInput in) throws IOException {
+        // MaximumCount for conformant array
+        in.align(Alignment.FOUR);
+        in.fullySkipBytes(4);
+    }
+
+    @Override
+    public void unmarshalEntity(PacketInput in) throws IOException {
+        // Structure Alignment: 4
+        in.align(Alignment.FOUR);
+        // Offset for varying array
+        // Alignment 4 - Already aligned
+        this.offset = readIndex("Offset", in);
+        // ActualCount for varying array
+        // Alignment 4 - Already aligned
+        final int actualCount = readIndex("ActualCount", in);
+        // If we expect a null terminator, then skip it when reading the string
+        this.length = (isNullTerminated() ? (actualCount - 1) : actualCount);
+    }
+
+    @Override
+    public void unmarshalDeferrals(PacketInput in) throws IOException {
+        // Read prefix (if any)
+        in.align(Alignment.TWO);
+        in.fullySkipBytes(2 * offset);
+        // Entities for conformant array
+        // Read subset
+        final StringBuilder sb = new StringBuilder(this.length);
+        for (int i = 0; i < this.length; i++) {
+            // <NDR: unsigned short>
+            // Alignment: 2 - Already aligned
+            sb.append(in.readChar());
+        }
+        this.value = sb.toString();
+        // Skip null terminator (if any)
+        // Alignment: 2 - Already aligned
+        if (isNullTerminated())
+            in.fullySkipBytes(2);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isNullTerminated(), getValue());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (! (obj instanceof WChar)) {
+            return false;
+        }
+        final WChar other = (WChar) obj;
+        return isNullTerminated() == other.isNullTerminated()
+                && Objects.equals(getValue(), other.getValue());
+    }
+
+    @Override
+    public String toString() {
+        return getValue() == null ? "null" : String.format("\"%s\"", getValue());
+    }
+
+    private int getCodePoints() {
+        return getValue().length() + (isNullTerminated() ? 1 : 0);
+    }
+
+    private int readIndex(String name, PacketInput in) throws IOException {
+        final long ret = in.readUnsignedInt();
+        // Don't allow array length or index values bigger than signed int
+        if (ret > Integer.MAX_VALUE) {
+            throw new UnmarshalException(String.format("%s %d > %d", name, ret, Integer.MAX_VALUE));
+        }
+        return (int) ret;
+    }
+}

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPRPolicyAccountDomInfo.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPRPolicyAccountDomInfo.java
@@ -179,6 +179,6 @@ public class Test_LSAPRPolicyAccountDomInfo {
         sid.setIdentifierAuthority(new byte[]{1, 2, 3, 4, 5, 6});
         sid.setSubAuthority(new long[]{1, 2, 3});
         obj.setDomainSid(sid);
-        assertEquals(obj.toString(), "LSAPR_POLICY_ACCOUNT_DOM_INFO{DomainName:RPC_UNICODE_STRING{value:\"test 123\", nullTerminated:false}, DomainSid:RPC_SID{Revision:1, SubAuthorityCount:3, IdentifierAuthority:[1, 2, 3, 4, 5, 6], SubAuthority: [1, 2, 3]}}");
+        assertEquals(obj.toString(), "LSAPR_POLICY_ACCOUNT_DOM_INFO{DomainName:\"test 123\", DomainSid:RPC_SID{Revision:1, SubAuthorityCount:3, IdentifierAuthority:[1, 2, 3, 4, 5, 6], SubAuthority: [1, 2, 3]}}");
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPRPolicyPrimaryDomInfo.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mslsad/objects/Test_LSAPRPolicyPrimaryDomInfo.java
@@ -180,6 +180,6 @@ public class Test_LSAPRPolicyPrimaryDomInfo {
         sid.setIdentifierAuthority(new byte[]{1, 2, 3, 4, 5, 6});
         sid.setSubAuthority(new long[]{1, 2, 3});
         obj.setSid(sid);
-        assertEquals(obj.toString(), "LSAPR_POLICY_PRIMARY_DOM_INFO{Name:RPC_UNICODE_STRING{value:\"test 123\", nullTerminated:false}, Sid:RPC_SID{Revision:1, SubAuthorityCount:3, IdentifierAuthority:[1, 2, 3, 4, 5, 6], SubAuthority: [1, 2, 3]}}");
+        assertEquals(obj.toString(), "LSAPR_POLICY_PRIMARY_DOM_INFO{Name:\"test 123\", Sid:RPC_SID{Revision:1, SubAuthorityCount:3, IdentifierAuthority:[1, 2, 3, 4, 5, 6], SubAuthority: [1, 2, 3]}}");
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRAliasGeneralInformation.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRAliasGeneralInformation.java
@@ -200,6 +200,6 @@ public class Test_SAMPRAliasGeneralInformation {
         obj.setName(RPCUnicodeString.NonNullTerminated.of("Name"));
         obj.setMemberCount(100L);
         obj.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
-        assertEquals(obj.toString(), "SAMPR_ALIAS_GENERAL_INFORMATION{Name:RPC_UNICODE_STRING{value:\"Name\", nullTerminated:false},MemberCount:100,AdminComment:RPC_UNICODE_STRING{value:\"AdminComment\", nullTerminated:false}}");
+        assertEquals(obj.toString(), "SAMPR_ALIAS_GENERAL_INFORMATION{Name:\"Name\",MemberCount:100,AdminComment:\"AdminComment\"}");
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRGroupGeneralInformation.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRGroupGeneralInformation.java
@@ -219,6 +219,6 @@ public class Test_SAMPRGroupGeneralInformation {
         obj.setAttributes(50);
         obj.setMemberCount(100L);
         obj.setAdminComment(RPCUnicodeString.NonNullTerminated.of("AdminComment"));
-        assertEquals(obj.toString(), "SAMPR_GROUP_GENERAL_INFORMATION{Name:RPC_UNICODE_STRING{value:\"Name\", nullTerminated:false},Attributes:50,MemberCount:100,AdminComment:RPC_UNICODE_STRING{value:\"AdminComment\", nullTerminated:false}}");
+        assertEquals(obj.toString(), "SAMPR_GROUP_GENERAL_INFORMATION{Name:\"Name\",Attributes:50,MemberCount:100,AdminComment:\"AdminComment\"}");
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRUserAllInformation.java
+++ b/src/test/java/com/rapid7/client/dcerpc/mssamr/objects/Test_SAMPRUserAllInformation.java
@@ -655,7 +655,7 @@ public class Test_SAMPRUserAllInformation {
         obj.setPrimaryGroupId(100L);
         obj.setUserName(RPCUnicodeString.NonNullTerminated.of("UserName1"));
         obj.setFullName(RPCUnicodeString.NonNullTerminated.of("FullName1"));
-        assertEquals(obj.toString(), "SAMPR_USER_ALL_INFORMATION{UserId:50, PrimaryGroupId:100, UserName:RPC_UNICODE_STRING{value:\"UserName1\", nullTerminated:false}, FullName:RPC_UNICODE_STRING{value:\"FullName1\", nullTerminated:false}}");
+        assertEquals(obj.toString(), "SAMPR_USER_ALL_INFORMATION{UserId:50, PrimaryGroupId:100, UserName:\"UserName1\", FullName:\"FullName1\"}");
     }
 
     private SAMPRUserAllInformation createEntity() {

--- a/src/test/java/com/rapid7/client/dcerpc/objects/Test_RPCUnicodeString.java
+++ b/src/test/java/com/rapid7/client/dcerpc/objects/Test_RPCUnicodeString.java
@@ -159,7 +159,6 @@ public class Test_RPCUnicodeString {
         RPCUnicodeString obj = create(nullTerminated);
         obj.setValue(value);
         obj.unmarshalEntity(in);
-        assertEquals(obj.isNullTerminated(), nullTerminated);
         assertEquals(obj.getValue(), value);
         assertEquals(bin.available(), 0);
     }
@@ -196,7 +195,6 @@ public class Test_RPCUnicodeString {
         obj.setValue("");
         obj.unmarshalDeferrals(in);
         assertEquals(bin.available(), 0);
-        assertEquals(obj.isNullTerminated(), nullTerminated);
         assertEquals(obj.getValue(), value);
     }
 
@@ -259,7 +257,7 @@ public class Test_RPCUnicodeString {
         RPCUnicodeString obj_ntn2 = new RPCUnicodeString.NonNullTerminated();
         assertEquals(obj_nt1, obj_nt2);
         assertEquals(obj_ntn1, obj_ntn2);
-        assertNotEquals(obj_nt1, obj_ntn1);
+        assertEquals(obj_nt1, obj_ntn1);
         obj_nt2.setValue("test123");
         obj_ntn2.setValue("test123");
         assertNotEquals(obj_nt1, obj_nt2);
@@ -273,9 +271,9 @@ public class Test_RPCUnicodeString {
     @DataProvider
     public Object[][] data_toString() {
         return new Object[][] {
-                {false, "test", "RPC_UNICODE_STRING{value:\"test\", nullTerminated:false}"},
-                {true, "test", "RPC_UNICODE_STRING{value:\"test\", nullTerminated:true}"},
-                {true, null, "RPC_UNICODE_STRING{value:null, nullTerminated:true}"}
+                {false, "test", "\"test\""},
+                {true, "test", "\"test\""},
+                {true, null, "null"}
         };
     }
 
@@ -286,7 +284,7 @@ public class Test_RPCUnicodeString {
         assertEquals(str.toString(), expected);
     }
 
-    private RPCUnicodeString create(boolean nullterminated) {
-        return nullterminated ? new RPCUnicodeString.NullTerminated() : new RPCUnicodeString.NonNullTerminated();
+    private RPCUnicodeString create(boolean nullTerminated) {
+        return nullTerminated ? new RPCUnicodeString.NullTerminated() : new RPCUnicodeString.NonNullTerminated();
     }
 }

--- a/src/test/java/com/rapid7/client/dcerpc/objects/Test_WChar.java
+++ b/src/test/java/com/rapid7/client/dcerpc/objects/Test_WChar.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017, Rapid7, Inc.
+ *
+ * License: BSD-3-clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ */
+
+package com.rapid7.client.dcerpc.objects;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class Test_WChar {
+
+    @Test
+    public void test_NullTerminated_of() {
+        String str = "test";
+        WChar.NullTerminated obj = WChar.NullTerminated.of(str);
+        assertSame(obj.getValue(), str);
+        assertTrue(obj.isNullTerminated());
+    }
+
+    @Test(expectedExceptions = {IllegalArgumentException.class},
+            expectedExceptionsMessageRegExp = "Expected non-null value")
+    public void test_NullTerminated_of_null() {
+        WChar.NullTerminated.of(null);
+    }
+
+    @Test
+    public void test_NonNullTerminated_of() {
+        String str = "test";
+        WChar.NonNullTerminated obj = WChar.NonNullTerminated.of(str);
+        assertSame(obj.getValue(), str);
+        assertFalse(obj.isNullTerminated());
+    }
+
+    @Test(expectedExceptions = {IllegalArgumentException.class},
+            expectedExceptionsMessageRegExp = "Expected non-null value")
+    public void test_NonNullTerminated_of_null() {
+        WChar.NonNullTerminated.of(null);
+    }
+
+    @DataProvider
+    public Object[][] data_isNullTerminated() {
+        return new Object[][] {
+                {false},
+                {true}
+        };
+    }
+
+    @Test(dataProvider = "data_isNullTerminated")
+    public void test_init_default(boolean nullTerminated) {
+        WChar wChar = create(nullTerminated);
+        assertSame(wChar.getValue(), "");
+        assertEquals(wChar.isNullTerminated(), nullTerminated);
+    }
+
+    @Test(dataProvider = "data_isNullTerminated",
+            expectedExceptions = {IllegalArgumentException.class},
+            expectedExceptionsMessageRegExp = "Expected non-null value")
+    public void test_setValue_null(boolean nullTerminated) {
+        WChar wChar = create(nullTerminated);
+        wChar.setValue(null);
+    }
+
+    @Test(dataProvider = "data_isNullTerminated")
+    public void test_setValue(boolean nullTerminated) {
+        WChar wChar = create(nullTerminated);
+        String value = "test";
+        wChar.setValue(value);
+        assertSame(wChar.getValue(), value);
+    }
+
+    @Test
+    public void test_hashCode() {
+        WChar obj_nt1 = new WChar.NullTerminated();
+        WChar obj_nt2 = new WChar.NullTerminated();
+        obj_nt2.setValue("test");
+        WChar obj_ntn1 = new WChar.NonNullTerminated();
+        WChar obj_ntn2 = new WChar.NonNullTerminated();
+        obj_ntn2.setValue("test");
+        assertEquals(obj_nt1.hashCode(), obj_nt1.hashCode());
+        assertNotEquals(obj_nt1.hashCode(), obj_nt2.hashCode());
+        assertNotEquals(obj_nt1.hashCode(), obj_ntn1.hashCode());
+        assertNotEquals(obj_nt1.hashCode(), obj_ntn2.hashCode());
+    }
+
+    @Test
+    public void test_equals() {
+        WChar obj_nt1 = new WChar.NullTerminated();
+        WChar obj_nt2 = new WChar.NullTerminated();
+        obj_nt2.setValue("test");
+        WChar obj_ntn1 = new WChar.NonNullTerminated();
+        WChar obj_ntn2 = new WChar.NonNullTerminated();
+        obj_ntn2.setValue("test");
+        assertEquals(obj_nt1, obj_nt1);
+        assertNotEquals(obj_nt1, obj_nt2);
+        assertNotEquals(obj_nt1, obj_ntn1);
+        assertNotEquals(obj_nt1, obj_ntn2);
+    }
+
+    @Test(dataProvider = "data_isNullTerminated")
+    public void test_toString_default(boolean nullTerminated) {
+        WChar obj = create(nullTerminated);
+        assertEquals(obj.toString(), "\"\"");
+    }
+
+    @Test(dataProvider = "data_isNullTerminated")
+    public void test_toString(boolean nullTerminated) {
+        WChar obj = create(nullTerminated);
+        String str = "testƟ123";
+        obj.setValue(str);
+        assertEquals(obj.toString(), "\"testƟ123\"");
+    }
+
+    // Marshalling logic is tested by Test_RPCUnicodeString
+
+    private WChar create(boolean nullTerminated) {
+        return nullTerminated ? new WChar.NullTerminated() : new WChar.NonNullTerminated();
+    }
+}


### PR DESCRIPTION
- This struct is analogous to w_char_t, and should be used instead of PacketInput/PacketOutput string variants
- RPCUnicodeString (which is a string buffer) now uses WChar as its w_char_t*
- Added unit tests where applicable
- Added documentation where missing