### PR TITLE
Fixes NPE encountered when no members are found within a group

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/SecurityAccountManagerService.java
@@ -821,12 +821,17 @@ public class SecurityAccountManagerService extends Service {
         return memberships;
     }
 
-    private MembershipWithAttributes[] parseGroupMemberships(final List<GroupMembership> list) {
-        final MembershipWithAttributes[] memberships = new MembershipWithAttributes[list.size()];
-        int i = 0;
-        for (GroupMembership groupMembership : list) {
-            memberships[i++] = new MembershipWithAttributes(groupMembership.getRelativeID(), groupMembership.getAttributes());
+    private MembershipWithAttributes[] parseGroupMemberships(final List<GroupMembership> groupMemberships) {
+        if (groupMemberships == null)
+            return new MembershipWithAttributes[0];
+        final MembershipWithAttributes[] ret = new MembershipWithAttributes[groupMemberships.size()];
+        for (int i = 0; i < ret.length; i++) {
+            final GroupMembership groupMembership = groupMemberships.get(i);
+            if (groupMembership == null)
+                ret[i] = null;
+            else
+                ret[i] = new MembershipWithAttributes(groupMembership.getRelativeID(), groupMembership.getAttributes());
         }
-        return memberships;
+        return ret;
     }
 }

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrGetMembersInGroupResponse.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrGetMembersInGroupResponse.java
@@ -30,13 +30,12 @@ public class SamrGetMembersInGroupResponse extends RequestResponse {
 
     @Override
     public void unmarshalResponse(PacketInput packetIn) throws IOException {
-        int referenceId = packetIn.readInt();
-        if (referenceId == 0) {
-            buffer = null;
-            return;
+        if (packetIn.readReferentID() != 0) {
+            this.buffer = new SAMPRGetMembersBuffer();
+            packetIn.readUnmarshallable(this.buffer);
+        } else {
+            this.buffer = null;
         }
-        buffer = new SAMPRGetMembersBuffer();
-        packetIn.readUnmarshallable(buffer);
     }
 
     public List<GroupMembership> getList() {

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRGetMembersBuffer.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/objects/SAMPRGetMembersBuffer.java
@@ -49,10 +49,6 @@ public class SAMPRGetMembersBuffer implements Unmarshallable {
 
     private List<GroupMembership> array;
 
-    public int getMemberCount() {
-        return memberCount;
-    }
-
     public List<GroupMembership> getGroupMembership() {
         return array;
     }
@@ -79,8 +75,10 @@ public class SAMPRGetMembersBuffer implements Unmarshallable {
     @Override
     public void unmarshalDeferrals(PacketInput in) throws IOException {
         in.align(Alignment.FOUR);
-        in.readUnmarshallable(members);
-        in.readUnmarshallable(attributes);
+        if (members != null)
+            in.readUnmarshallable(members);
+        if (attributes != null)
+            in.readUnmarshallable(attributes);
         array = new ArrayList<>(memberCount);
         for (int i = 0; i < memberCount; i++) {
             GroupMembership member = new GroupMembership();

--- a/src/main/java/com/rapid7/client/dcerpc/objects/RPCConformantArray.java
+++ b/src/main/java/com/rapid7/client/dcerpc/objects/RPCConformantArray.java
@@ -21,6 +21,7 @@ package com.rapid7.client.dcerpc.objects;
 import java.io.IOException;
 import com.rapid7.client.dcerpc.io.PacketInput;
 import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.io.ndr.Alignment;
 import com.rapid7.client.dcerpc.io.ndr.Marshallable;
 import com.rapid7.client.dcerpc.io.ndr.Unmarshallable;
 
@@ -44,6 +45,7 @@ public abstract class RPCConformantArray<T> implements Unmarshallable, Marshalla
 
     @Override
     public void unmarshalPreamble(PacketInput in) throws IOException {
+        in.align(Alignment.FOUR);
         maxCount = in.readInt();
     }
 
@@ -55,6 +57,7 @@ public abstract class RPCConformantArray<T> implements Unmarshallable, Marshalla
 
     @Override
     public void marshalPreamble(PacketOutput out) throws IOException {
+        out.align(Alignment.FOUR);
         out.writeInt(maxCount);
     }
 


### PR DESCRIPTION
Fixes the following:
```
java.lang.NullPointerException
	at com.rapid7.client.dcerpc.io.PacketInput.readUnmarshallable(PacketInput.java:31)
	at com.rapid7.client.dcerpc.mssamr.objects.SAMPRGetMembersBuffer.unmarshalDeferrals(SAMPRGetMembersBuffer.java:82)
	at com.rapid7.client.dcerpc.io.PacketInput.readUnmarshallable(PacketInput.java:33)
	at com.rapid7.client.dcerpc.mssamr.messages.SamrGetMembersInGroupResponse.unmarshalResponse(SamrGetMembersInGroupResponse.java:39)
	at com.rapid7.client.dcerpc.messages.RequestResponse.unmarshal(RequestResponse.java:84)
	at com.rapid7.client.dcerpc.transport.RPCTransport.call(RPCTransport.java:116)
	at com.rapid7.client.dcerpc.service.Service.call(Service.java:46)
	at com.rapid7.client.dcerpc.service.Service.callExpect(Service.java:55)
	at com.rapid7.client.dcerpc.service.Service.callExpectSuccess(Service.java:50)
	at com.rapid7.client.dcerpc.mssamr.SecurityAccountManagerService.getMembersForGroup(SecurityAccountManagerService.java:743)
```