### PR TITLE
Add github templates

### DIFF
--- a/.github/CONTRIBUTING
+++ b/.github/CONTRIBUTING
@@ -1,0 +1,15 @@
+# Contributing to smbj-rpc
+
+The users and maintainers of smbj-rpc would greatly appreciate any contributions
+you can make to the project. These contributions typically come in the form of
+filed bugs/issues or pull requests (PRs). These contributions routinely result
+in [new versions of the smbj-rpc library to be released](https://github.com/rapid7/smbj-rpc/releases).
+The process for each is outlined below.
+
+## Contributing Issues / Bug Reports
+
+If you encounter any bugs or problems with smbj-rpc, please file them
+[here](https://github.com/rapid7/smbj-rpc/issues/new/choose), providing as much detail as
+possible. If the bug is straight-forward enough and you understand the fix for
+the bug well enough, you may take the simpler, less-paperwork route and simply
+file a pull request with the fix and the necessary details.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Do this...
+2. Do that...
+3. Then something happens...
+
+Code that reproduces the behavior:
+```java
+// paste code here, or create a gist, or link to public code snippet
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+
+**Environment (please complete the following information):**
+ - Operating System: 
+ - Java Version: 
+ - Library Version: 
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,24 @@
+## Description
+A detailed description of your changes.
+
+
+## Motivation and Context
+Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.
+
+
+## How Has This Been Tested?
+A clear and concise description of your changes were tested.
+
+
+## Types of changes
+<!--- What types of changes does your code introduce? Remove any that do not apply: -->
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to change)
+
+
+## Checklist:
+<!--- After submitting the PR, check all of the boxes that apply. -->
+- [ ] I have updated the documentation accordingly (or changes are not required).
+- [ ] I have added tests to cover my changes (or new tests are not required).
+- [ ] All new and existing tests passed.


### PR DESCRIPTION
Add github templates for:

- contributing info (displayed in pull request workflow)
- new pull requests
- new issues

To see what the new issue workflow looks like, see recog-java:

https://github.com/rapid7/recog-java/issues/new/choose
