### PR TITLE
Get domain names

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
@@ -321,6 +321,24 @@ public class LocalSecurityAuthorityService extends Service {
         }
         return mappedNames;
     }
+	
+	public String[] lookupDomainNamesForSIDs(final PolicyHandle policyHandle, final LSAPLookupLevel lookupLevel, SID ... sids)
+            throws IOException {
+        final LsarLookupSIDsRequest request = new LsarLookupSIDsRequest(parseHandle(policyHandle), parseSIDs(sids),
+                lookupLevel.getValue());
+        final LsarLookupSIDsResponse lsarLookupSIDsResponse = callExpect(request, "LsarLookupSIDs",
+                SystemErrorCode.ERROR_SUCCESS,
+                SystemErrorCode.STATUS_SOME_NOT_MAPPED,
+                SystemErrorCode.STATUS_NONE_MAPPED);
+        LSAPRTrustInformation[] domainNameArray = lsarLookupSIDsResponse.getReferencedDomains().getDomains();
+        if (domainNameArray == null)
+            domainNameArray = new LSAPRTrustInformation[0];
+        final String[] mappedDomainNames = new String[domainNameArray.length];
+        for (int i = 0; i < domainNameArray.length; i++) {
+            mappedDomainNames[i] = domainNameArray[i].getName().getValue();
+        }
+        return mappedDomainNames;
+    }
 
     private PolicyHandle parsePolicyHandle(final byte[] handle) {
         return new PolicyHandle(handle);

--- a/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mslsad/LocalSecurityAuthorityService.java
@@ -322,6 +322,16 @@ public class LocalSecurityAuthorityService extends Service {
         return mappedNames;
     }
 	
+	/**
+     * @param policyHandle A valid policy handle obtained from {@link #openPolicyHandle()}.
+     * @param lookupLevel Look up level as defined in {@link LSAPLookupLevel}.
+     * @param sids Array of {@link SID}s to lookup
+     * @return An array of domain names. Each entry index in this list corresponds to the same entry index in
+     *         the provided sids array. The original SID would be returned as a string if the given
+     *         {@link SID} was not mapped.
+     * @throws IOException Thrown if either a communication failure is encountered, or the call
+     * returns an unsuccessful response.
+     */
 	public String[] lookupDomainNamesForSIDs(final PolicyHandle policyHandle, final LSAPLookupLevel lookupLevel, SID ... sids)
             throws IOException {
         final LsarLookupSIDsRequest request = new LsarLookupSIDsRequest(parseHandle(policyHandle), parseSIDs(sids),


### PR DESCRIPTION
…alSecurityAuthorityService.java to get a list of domain names for the corresponding SIDs.

## Description
Added a function with name lookupDomainNamesForSIDs in src\main\java\com\rapid7\client\dcerpc\mslsad\LocalSecurityAuthorityService.java to get a list of domain names for the corresponding SIDs. This function is similar to the function which is used to get translated names for the corresponding SIDs.

## Motivation and Context
Getting a username along with its domain name was required while working on a project. But the current library code do not offer this functionality. Extending the LocalSecurityAuthorityService.java and adding a function was a solution but it would be easier if smbj-rpc offered this functionality.

## How Has This Been Tested?
This has been tested by using single as well as multiple SIDs as arguments. The response is as expected i.e. an array of domain names.


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [check ] I have updated the documentation accordingly (or changes are not required).
- [ check] I have added tests to cover my changes (or new tests are not required).
- [ check] All new and existing tests passed.
