### PR TITLE
Added SamrUnicodeChangePasswordUser2 request and response classes for…

### DIFF
--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrUnicodeChangePasswordUser2Request.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrUnicodeChangePasswordUser2Request.java
@@ -1,0 +1,66 @@
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+import com.rapid7.client.dcerpc.io.PacketOutput;
+import com.rapid7.client.dcerpc.messages.RequestCall;
+import com.rapid7.client.dcerpc.objects.RPCUnicodeString;
+
+import java.io.IOException;
+
+/**
+ * <a href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/acb3204a-da8b-478e-9139-1ea589edb880">SamrUnicodeChangePasswordUser2</a>
+ * <blockquote><pre>
+ * The SamrUnicodeChangePasswordUser2 method changes a user's password.
+ *
+ * long SamrUnicodeChangePasswordUser2(
+ *  [in] handle_t BindingHandle,
+ *  [in, unique] PRPC_UNICODE_STRING ServerName,
+ *  [in] PRPC_UNICODE_STRING UserName,
+ *  [in, unique] PSAMPR_ENCRYPTED_USER_PASSWORD NewPasswordEncryptedWithOldNt,
+ *  [in, unique] PENCRYPTED_NT_OWF_PASSWORD OldNtOwfPasswordEncryptedWithNewNt,
+ *  [in] unsigned char LmPresent,
+ *  [in, unique] PSAMPR_ENCRYPTED_USER_PASSWORD NewPasswordEncryptedWithOldLm,
+ *  [in, unique] PENCRYPTED_LM_OWF_PASSWORD OldLmOwfPasswordEncryptedWithNewNt
+ );
+ * </pre></blockquote>
+ */
+public class SamrUnicodeChangePasswordUser2Request extends RequestCall<SamrUnicodeChangePasswordUser2Response> {
+
+    public static final short OP_NUM = 55;
+    private final byte[] domainHandle;
+    private RPCUnicodeString.NonNullTerminated serverName;
+    private RPCUnicodeString.NonNullTerminated userName;
+    private byte[] newPasswordEncryptedWithOldNt;
+    private byte[] oldNtOwfPasswordEncryptedWithNewNt;
+    private int lmPresent;
+    private byte[] newPasswordEncryptedWithOldLm;
+    private byte[] oldLmOwfPasswordEncryptedWithNewNt;
+
+    public SamrUnicodeChangePasswordUser2Request(byte[] domainHandle, RPCUnicodeString.NonNullTerminated serverName, RPCUnicodeString.NonNullTerminated userName, byte[] newPasswordEncryptedWithOldNt, byte[] oldNtOwfPasswordEncryptedWithNewNt,  byte[] newPasswordEncryptedWithOldLm, byte[] oldLmOwfPasswordEncryptedWithNewNt) {
+        super(OP_NUM);
+        this.domainHandle = domainHandle;
+        this.serverName = serverName;
+        this.userName = userName;
+        this.newPasswordEncryptedWithOldNt = newPasswordEncryptedWithOldNt;
+        this.oldNtOwfPasswordEncryptedWithNewNt = oldNtOwfPasswordEncryptedWithNewNt;
+        this.newPasswordEncryptedWithOldLm = newPasswordEncryptedWithOldLm;
+        this.oldLmOwfPasswordEncryptedWithNewNt = oldLmOwfPasswordEncryptedWithNewNt;
+    }
+
+    @Override
+    public void marshal(PacketOutput packetOut) throws IOException {
+        lmPresent = 0;
+        packetOut.write(this.domainHandle);
+        packetOut.writeMarshallable(this.serverName);
+        packetOut.writeMarshallable(this.userName);
+        packetOut.write(this.newPasswordEncryptedWithOldNt);
+        packetOut.write(this.oldNtOwfPasswordEncryptedWithNewNt);
+        packetOut.writeInt(this.lmPresent);
+        packetOut.write(this.newPasswordEncryptedWithOldLm);
+        packetOut.write(this.oldLmOwfPasswordEncryptedWithNewNt);
+    }
+
+    @Override
+    public SamrUnicodeChangePasswordUser2Response getResponseObject() {
+        return new SamrUnicodeChangePasswordUser2Response();
+    }
+}

--- a/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrUnicodeChangePasswordUser2Response.java
+++ b/src/main/java/com/rapid7/client/dcerpc/mssamr/messages/SamrUnicodeChangePasswordUser2Response.java
@@ -1,0 +1,16 @@
+package com.rapid7.client.dcerpc.mssamr.messages;
+
+
+import com.rapid7.client.dcerpc.io.PacketInput;
+import com.rapid7.client.dcerpc.messages.RequestResponse;
+
+import java.io.IOException;
+
+
+public class SamrUnicodeChangePasswordUser2Response extends RequestResponse {
+
+    @Override
+    public void unmarshalResponse(PacketInput packetIn) throws IOException {
+
+    }
+}


### PR DESCRIPTION
## Description

To implement the SamrUnicodeChangePasswordUser2 method I need a set of encryption operations.  I need some suggestions on how to create them. For example in python impacket project:

`
oldPwdHashNT = ntlm.NTOWFv1(oldPassword)
newPwdHashNT = ntlm.NTOWFv1(newPassword)
samUser = SAMPR_USER_PASSWORD()
samUser['Length'] = len(newPassword)*2
pwdBuff = samUser.getData()
rc4 = ARC4.new(oldPwdHashNT)
encBuf = rc4.encrypt(pwdBuff)
request['NewPasswordEncryptedWithOldNt']['Buffer'] = encBuf
request['OldNtOwfPasswordEncryptedWithNewNt'] = crypto.SamEncryptNTLMHash(oldPwdHashNT, newPwdHashNT)
request['LmPresent'] = 0
request['NewPasswordEncryptedWithOldLm'] = NULL
request['OldLmOwfPasswordEncryptedWithNewNt'] = NULL
`
For example, I could not create the SamEncryptNTLMHash method, which has the LMOWFv1 method in the NtlmV1Functions class.
