### PR TITLE
Overriding the vulnerable version of bouncy castle in smbj

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
    <properties>
       <thirdparty.bouncycastle.version>1.78.1</thirdparty.bouncycastle.version>
-      <thirdparty.commons-io.version>2.7<</thirdparty.commons-io.version>
+      <thirdparty.commons-io.version>2.7</thirdparty.commons-io.version>
       <thirdparty.commons-lang3.version>3.4</thirdparty.commons-lang3.version>
       <thirdparty.guava.version>33.0.0-jre</thirdparty.guava.version>
       <thirdparty.hamcrest.version>1.3</thirdparty.hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
    <properties>
       <thirdparty.bouncycastle.version>1.78.1</thirdparty.bouncycastle.version>
-      <thirdparty.commons-io.version>2.14.0</thirdparty.commons-io.version>
+      <thirdparty.commons-io.version>2.7<</thirdparty.commons-io.version>
       <thirdparty.commons-lang3.version>3.4</thirdparty.commons-lang3.version>
       <thirdparty.guava.version>33.0.0-jre</thirdparty.guava.version>
       <thirdparty.hamcrest.version>1.3</thirdparty.hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,8 @@
    </distributionManagement>
 
    <properties>
-      <thirdparty.commons-io.version>2.7</thirdparty.commons-io.version>
+      <thirdparty.bouncycastle.version>1.78.1</thirdparty.bouncycastle.version>
+      <thirdparty.commons-io.version>2.14.0</thirdparty.commons-io.version>
       <thirdparty.commons-lang3.version>3.4</thirdparty.commons-lang3.version>
       <thirdparty.guava.version>33.0.0-jre</thirdparty.guava.version>
       <thirdparty.hamcrest.version>1.3</thirdparty.hamcrest.version>
@@ -59,6 +60,13 @@
    </properties>
 
    <dependencies>
+     <!-- the version of bouncycastle in smbj is vulnerable     -->
+     <dependency>
+       <groupId>org.bouncycastle</groupId>
+       <artifactId>bcprov-jdk18on</artifactId>
+       <version>${thirdparty.bouncycastle.version}</version>
+       <scope>runtime</scope>
+     </dependency>
       <!-- 3rdparty dependencies. -->
       <dependency>
          <groupId>commons-io</groupId>


### PR DESCRIPTION
## Description
Overriding the bouncycastle dependency bcprov-jdk18on in SMBJ as that version has vulnerabilities. 
Bumped the version of commons-io to a version without vulnerabilities.


## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.


## How Has This Been Tested?
Ran existing unit and integration tests


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
