### PR TITLE
NEX-59203: Bump Commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <groupId>com.rapid7.client</groupId>
    <artifactId>dcerpc</artifactId>
    <packaging>jar</packaging>
-   <version>0.12.13-SNAPSHOT</version>
+   <version>0.12.13-COMMONS-BUMP-SNAPSHOT</version>
    <name>dcerpc</name>
    <url>https://www.rapid7.com</url>
    <description>DCE-RPC implementation capable of using SMBv2 via SMBJ to invoke remote procedure calls (RPC) over the IPC$ named pipe.</description>
@@ -45,13 +45,13 @@
 
    <properties>
       <thirdparty.bouncycastle.version>1.78.1</thirdparty.bouncycastle.version>
-      <thirdparty.commons-io.version>2.7</thirdparty.commons-io.version>
-      <thirdparty.commons-lang3.version>3.4</thirdparty.commons-lang3.version>
+      <thirdparty.commons-io.version>2.18.0</thirdparty.commons-io.version>
+      <thirdparty.commons-lang3.version>3.17.0</thirdparty.commons-lang3.version>
       <thirdparty.guava.version>33.4.0-jre</thirdparty.guava.version>
       <thirdparty.hamcrest.version>1.3</thirdparty.hamcrest.version>
       <thirdparty.junit.version>5.7.2</thirdparty.junit.version>
       <thirdparty.mockito.version>1.10.19</thirdparty.mockito.version>
-      <thirdparty.smbj.version>0.12.2</thirdparty.smbj.version>
+      <thirdparty.smbj.version>0.12.13-COMMONS-BUMP-SNAPSHOT</thirdparty.smbj.version>
       <thirdparty.testng.version>6.11</thirdparty.testng.version>
       <thirdparty.testcontainers.version>1.16.0</thirdparty.testcontainers.version>
       <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
## Description
This pull request updates the `pom.xml` file to reflect dependency version changes and align with a new snapshot versioning scheme. The most significant changes include updates to third-party library versions and a modification to the project version.

### Dependency version updates:

* Updated `thirdparty.commons-io.version` from `2.7` to `2.18.0` to use a more recent version of the Commons IO library.
* Updated `thirdparty.commons-lang3.version` from `3.4` to `3.17.0` to leverage enhancements in the Commons Lang library.
* Updated `thirdparty.smbj.version` from `0.12.2` to `0.12.13-COMMONS-BUMP-SNAPSHOT` for compatibility with the new snapshot versioning scheme.

### Project version update:

* Changed the project version from `0.12.13-SNAPSHOT` to `0.12.13-COMMONS-BUMP-SNAPSHOT` to reflect the dependency updates and align with the new versioning convention.


## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.


## How Has This Been Tested?
A clear and concise description of your changes were tested.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
